### PR TITLE
chore: add Renovate and Dependabot dependency management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/Windows 10/GUI"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "enabledManagers": ["nuget"]
+}


### PR DESCRIPTION
This pull request introduces automated dependency management for the project by configuring both Dependabot and Renovate.

Dependency management automation:

* Added a `.github/dependabot.yml` configuration to enable Dependabot for NuGet packages in the `/Windows 10/GUI` directory, scheduling weekly update checks and standardizing commit messages with a "chore" prefix.
* Added a `renovate.json` configuration to enable Renovate for NuGet dependency updates, extending the recommended configuration and specifying the NuGet manager.