### PR TITLE
migrate: System.Management → CIM + specific exception types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,7 @@ without a platform guard. The CLI runs on Linux too.
 
 ## Pull Request Rules
 
+- **Do NOT open a pull request unless the user explicitly asks.** Commit and push only; stop there.
 - One PR per logical concern (error handling, deduplication, API migration, etc.)
 - Describe **what** changed and **why** in the PR body
 - Call out any `TODO(AI)` items explicitly in the PR description

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,146 @@
+# AI Coding Assistant Guide — pcHealth
+
+> If you are an AI assistant (Claude, Copilot, Cursor, etc.), read this file
+> before making any changes to this repository.
+> Inspired by: https://github.com/torvalds/linux/blob/master/Documentation/process/coding-assistants.rst
+
+---
+
+## Project Structure
+
+This project has **two separate codebases**. Know which one you're in:
+
+| Part | Location | Language | Purpose |
+|---|---|---|---|
+| CLI | `src/CLI/` | PowerShell 7 + Bash | Cross-platform terminal health tool |
+| GUI | `src/GUI/pcHealth/` | C# / WinUI 3 (.NET) | Windows-only graphical frontend |
+
+Do not mix patterns between them. C# APIs do not belong in PowerShell scripts and vice versa.
+
+---
+
+## Working Style: Caveman First
+
+This project follows the **caveman approach**:
+https://github.com/JuliusBrussee/caveman
+
+- Make **small, focused changes** — one concern per commit
+- Prefer **boring, readable solutions** over clever abstractions
+- **Do not refactor working code** unless there is a clear reason
+- If you're unsure, leave a `// TODO(AI): ...` comment and move on
+- Build must pass after every commit
+
+---
+
+## Language & Comments
+
+- Code and comments are written in **English**
+- Comments explain **WHY**, not WHAT
+- No obvious comments (`// increment i` on `i++` is noise)
+
+---
+
+## Deprecated APIs — Avoid These
+
+### C# / .NET (GUI — `src/GUI/`)
+
+The GUI uses WinUI 3 on .NET. Replace legacy APIs with their modern equivalents:
+
+| Deprecated / Avoid | Preferred | Why |
+|---|---|---|
+| `System.Management.ManagementObjectSearcher` | `Microsoft.Management.Infrastructure` (`CimSession`, `CimInstance`) | `System.Management` uses DCOM under the hood — slow, Windows-only, and discouraged in modern .NET. The CIM/MI library uses WSMan and is the Microsoft-recommended replacement. |
+| `global using System.Management` (already in `GlobalUsings.cs`) | Migrate query by query to `CimSession.QueryInstances()` | The global using pulls in the entire legacy namespace project-wide |
+| `Process.Start()` without `CancellationToken` support | Wrap with `async`/`await` and pass a `CancellationToken` where the call can hang | Fire-and-forget `Process.Start` cannot be cancelled or awaited cleanly |
+| `catch { }` (empty catch) | `catch (Exception ex) { /* log ex */ }` | Silent swallowing hides real failures; always log or surface |
+| `catch (Exception)` (bare) | Catch specific types: `IOException`, `UnauthorizedAccessException`, `COMException`, etc. | Overly broad catches mask bugs |
+| Raw string path building (`dir + "\\" + file`) | `Path.Combine(dir, file)` | Breaks on path edge cases; `Path.Combine` handles separators correctly |
+| `Microsoft.Win32.Registry.OpenSubKey()` without null-check | Always null-check the returned key before accessing it | Registry keys may not exist on all Windows builds |
+
+**CIM migration example** — replace this:
+```csharp
+// OLD — System.Management (DCOM, legacy)
+using var searcher = new ManagementObjectSearcher(
+    "SELECT Caption FROM Win32_OperatingSystem");
+foreach (ManagementObject obj in searcher.Get())
+    Console.WriteLine(obj["Caption"]);
+```
+
+With this:
+```csharp
+// NEW — Microsoft.Management.Infrastructure (CIM/WSMan, modern)
+using var session = CimSession.Create(null); // null = local machine
+foreach (var instance in session.QueryInstances(
+    "root/cimv2", "WQL", "SELECT Caption FROM Win32_OperatingSystem"))
+    Console.WriteLine(instance.CimInstanceProperties["Caption"].Value);
+```
+
+### PowerShell 7 (CLI — `src/CLI/`)
+
+| Deprecated / Avoid | Preferred | Why |
+|---|---|---|
+| `Get-WmiObject` | `Get-CimInstance` | WMI over DCOM; removed from PowerShell 6+. CIM is the modern standard |
+| `wmic.exe` via `Invoke-Expression` or `Start-Process` | `Get-CimInstance` | `wmic.exe` is **removed** in Windows 11 25H2 |
+| `Invoke-Expression` (`iex`) | Explicit script blocks | Arbitrary code execution; hard to audit and dangerous |
+| `$ErrorActionPreference = 'SilentlyContinue'` set globally | `-ErrorAction SilentlyContinue` per call | Global silencing hides real errors in unrelated code |
+| `Write-Host` for data/pipeline output | `Write-Output` or `return` | `Write-Host` bypasses the pipeline; only use it for user-facing display text |
+| String concatenation for paths (`"$dir\$file"`) | `Join-Path $dir $file` | Handles both `\` and `/` correctly on Windows and Linux |
+| Bare `ls`, `cat`, `cp` aliases | `Get-ChildItem`, `Get-Content`, `Copy-Item` | Aliases are unreliable in strict or non-interactive environments |
+
+### Bash (CLI Linux — `src/CLI/start.sh`)
+
+| Avoid | Prefer | Why |
+|---|---|---|
+| Unquoted variables (`$VAR`) | Quoted (`"$VAR"`) | Breaks on paths with spaces |
+| `ls` in scripts | `find` or explicit glob | `ls` output is not reliably parseable |
+| `[ ]` (single bracket) | `[[ ]]` (double bracket) | Double bracket is safer and supports regex |
+
+---
+
+## Platform Guards — Mandatory
+
+Both CLI and C# code must guard platform-specific calls:
+
+**PowerShell:**
+```powershell
+if ($IsWindows) { Get-CimInstance Win32_Processor }
+if ($IsLinux)   { & lscpu }
+```
+
+**C#:**
+```csharp
+if (OperatingSystem.IsWindows()) { /* registry, CIM, WinUI */ }
+```
+
+Never call `Get-CimInstance`, registry reads, `Get-PnpDevice`, or WinUI APIs
+without a platform guard. The CLI runs on Linux too.
+
+---
+
+## Error Handling
+
+- Use specific exception types (`IOException`, `UnauthorizedAccessException`,
+  `COMException`, `DirectoryNotFoundException`), not bare `catch (Exception)`
+- Do not swallow exceptions silently — always log or surface them
+- Every CIM query, registry read, file I/O, and `Process.Start` must have error handling
+- In PowerShell: always use `-ErrorAction SilentlyContinue` on fallible cmdlets
+  and follow up with a `Write-Warning` or fallback
+
+---
+
+## Pull Request Rules
+
+- One PR per logical concern (error handling, deduplication, API migration, etc.)
+- Describe **what** changed and **why** in the PR body
+- Call out any `TODO(AI)` items explicitly in the PR description
+- Do not change public-facing behavior without discussion
+
+---
+
+## What NOT to Do
+
+- Do not introduce new NuGet packages without noting them in the PR description
+- Do not convert working code to a different style just for aesthetics
+- Do not remove functionality
+- Do not rewrite the whole codebase in one PR
+- Do not add `using System.Management` anywhere — migrate away from it instead
+- Do not call `wmic.exe` — it is removed in Windows 11 25H2

--- a/src/GUI/pcHealth/GlobalUsings.cs
+++ b/src/GUI/pcHealth/GlobalUsings.cs
@@ -7,7 +7,6 @@ global using Microsoft.UI.Xaml;
 global using Microsoft.UI.Xaml.Controls;
 global using Microsoft.UI.Xaml.Media;
 global using Microsoft.UI.Xaml.Navigation;
-global using System.Management;
 global using Windows.ApplicationModel.DataTransfer;
 global using Windows.Graphics;
 global using Windows.Storage.Pickers;

--- a/src/GUI/pcHealth/KeyExtractor.cs
+++ b/src/GUI/pcHealth/KeyExtractor.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics;
 using System.Text.RegularExpressions;
+using Microsoft.Management.Infrastructure;
 using Microsoft.Win32;
 
 namespace pcHealth;
@@ -60,17 +62,25 @@ public static class KeyExtractor
     {
         try
         {
-            using var searcher = new ManagementObjectSearcher(
-                "SELECT Caption, BuildNumber FROM Win32_OperatingSystem");
-            foreach (ManagementObject obj in searcher.Get())
+            using var session = CimSession.Create(null);
+            foreach (var instance in session.QueryInstances(
+                "root/cimv2", "WQL",
+                "SELECT Caption, BuildNumber FROM Win32_OperatingSystem"))
             {
-                var caption = obj["Caption"]?.ToString()?.Trim();
-                var build = obj["BuildNumber"]?.ToString();
+                var caption = instance.CimInstanceProperties["Caption"]?.Value?.ToString()?.Trim();
+                var build = instance.CimInstanceProperties["BuildNumber"]?.Value?.ToString();
                 if (caption != null)
                     return $"{caption} (Build {build})";
             }
         }
-        catch { /* fall through to default */ }
+        catch (CimException ex)
+        {
+            Debug.WriteLine($"[KeyExtractor] CIM query failed for OS caption: {ex.Message}");
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            Debug.WriteLine($"[KeyExtractor] Access denied querying OS caption: {ex.Message}");
+        }
         return "Windows (version unknown)";
     }
 
@@ -78,16 +88,24 @@ public static class KeyExtractor
     {
         try
         {
-            using var searcher = new ManagementObjectSearcher(
-                "SELECT OA3xOriginalProductKey FROM SoftwareLicensingService");
-            foreach (ManagementObject obj in searcher.Get())
+            using var session = CimSession.Create(null);
+            foreach (var instance in session.QueryInstances(
+                "root/cimv2", "WQL",
+                "SELECT OA3xOriginalProductKey FROM SoftwareLicensingService"))
             {
-                var key = obj["OA3xOriginalProductKey"]?.ToString();
+                var key = instance.CimInstanceProperties["OA3xOriginalProductKey"]?.Value?.ToString();
                 if (!string.IsNullOrWhiteSpace(key) && IsValidFormat(key))
                     return key;
             }
         }
-        catch { }
+        catch (CimException ex)
+        {
+            Debug.WriteLine($"[KeyExtractor] CIM query failed for OA3 key: {ex.Message}");
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            Debug.WriteLine($"[KeyExtractor] Access denied querying OA3 key: {ex.Message}");
+        }
         return null;
     }
 
@@ -141,7 +159,19 @@ public static class KeyExtractor
 
             return IsValidFormat(result) ? result : null;
         }
-        catch { }
+        catch (UnauthorizedAccessException ex)
+        {
+            Debug.WriteLine($"[KeyExtractor] Registry access denied for DigitalProductId: {ex.Message}");
+        }
+        catch (System.Security.SecurityException ex)
+        {
+            Debug.WriteLine($"[KeyExtractor] Registry security error for DigitalProductId: {ex.Message}");
+        }
+        catch (ArgumentOutOfRangeException ex)
+        {
+            // DigitalProductId blob shorter than expected — can occur on unusual Windows editions.
+            Debug.WriteLine($"[KeyExtractor] DigitalProductId blob malformed: {ex.Message}");
+        }
         return null;
     }
 

--- a/src/GUI/pcHealth/pcHealth.csproj
+++ b/src/GUI/pcHealth/pcHealth.csproj
@@ -34,8 +34,8 @@
     <PackageReference Include="Microsoft.WindowsAppSDK"    Version="1.8.260317003" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1721"
                       IncludeAssets="build" />
-    <!-- WMI access for OA3 key extraction and OS info -->
-    <PackageReference Include="System.Management" Version="10.0.6" />
+    <!-- CIM/MI library for OS info and OA3 key extraction (replaces legacy System.Management/DCOM) -->
+    <PackageReference Include="Microsoft.Management.Infrastructure" Version="3.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## What changed

Migrated `KeyExtractor.cs` from `System.Management` (DCOM) to `Microsoft.Management.Infrastructure` (CIM/WSMan), and replaced all bare `catch {}` blocks with specific exception types.

### API migration

| Before | After |
|--------|-------|
| `ManagementObjectSearcher` + `ManagementObject` | `CimSession.QueryInstances` + `CimInstance` |
| `global using System.Management` | removed |
| NuGet: `System.Management 10.0.6` | NuGet: `Microsoft.Management.Infrastructure 3.0.0` |

`System.Management` wraps DCOM — same stack `wmic.exe` used (removed in Windows 11 25H2). `Microsoft.Management.Infrastructure` uses WSMan and is Microsoft's recommended modern replacement.

### Error handling

Replaced three silent `catch {}` blocks:

- `GetOsCaption()` — catches `CimException`, `UnauthorizedAccessException`
- `GetKeyFromOA3()` — catches `CimException`, `UnauthorizedAccessException`
- `GetKeyFromDigitalProductId()` — catches `UnauthorizedAccessException`, `System.Security.SecurityException`, `ArgumentOutOfRangeException` (guards against a malformed/short DigitalProductId blob)

All catch blocks log to `Debug.WriteLine` so failures appear in diagnostics output without crashing the UI.

### Also included

- `AGENTS.md`: document the `System.Management` → CIM migration rule + rule to never open PRs without explicit user request

## New NuGet dependency

`Microsoft.Management.Infrastructure 3.0.0` — Windows-only CIM/MI client library.

## TODO(AI) items

None.