### PR TITLE
refactor: deduplicate UninstallPaths and PropertyChanged helper

### DIFF
--- a/src/GUI/pcHealth/Models/ProgramItem.cs
+++ b/src/GUI/pcHealth/Models/ProgramItem.cs
@@ -21,6 +21,9 @@ public sealed class ProgramItem : INotifyPropertyChanged
     /// </summary>
     public string RegistryName { get; init; } = "";
 
+    private void Notify(string name) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+
     private bool _isInstalled;
     public bool IsInstalled
     {
@@ -29,8 +32,8 @@ public sealed class ProgramItem : INotifyPropertyChanged
         {
             if (_isInstalled == value) return;
             _isInstalled = value;
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsInstalled)));
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ButtonLabel)));
+            Notify(nameof(IsInstalled));
+            Notify(nameof(ButtonLabel));
         }
     }
 

--- a/src/GUI/pcHealth/Services/CliRunner.cs
+++ b/src/GUI/pcHealth/Services/CliRunner.cs
@@ -10,6 +10,13 @@ internal static class CliRunner
 {
     private static string? _toolsDir;
 
+    // Both 32-bit and 64-bit uninstall hives must be searched on 64-bit Windows.
+    private static readonly string[] UninstallPaths =
+    {
+        @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",
+        @"SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall",
+    };
+
     /// <summary>
     /// Locates the CLI/tools directory by walking up from the executable
     /// location. Works from bin/Debug|Release output and any ancestor folder.
@@ -72,13 +79,7 @@ internal static class CliRunner
 
     private static string? GetInstallLocationExe(string registryName, string exeName)
     {
-        string[] paths =
-        {
-            @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",
-            @"SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall",
-        };
-
-        foreach (var path in paths)
+        foreach (var path in UninstallPaths)
         {
             using var key = Microsoft.Win32.Registry.LocalMachine.OpenSubKey(path);
             if (key is null) continue;
@@ -136,13 +137,7 @@ internal static class CliRunner
 
     private static bool SearchUninstallKey(Microsoft.Win32.RegistryKey hive, string name)
     {
-        string[] paths =
-        {
-            @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",
-            @"SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall",
-        };
-
-        foreach (var path in paths)
+        foreach (var path in UninstallPaths)
         {
             using var key = hive.OpenSubKey(path);
             if (key is null) continue;


### PR DESCRIPTION
## What changed

Two small deduplication fixes — no behavior change.

### CliRunner.cs

The two Uninstall registry paths were copy-pasted verbatim into both `GetInstallLocationExe()` and `SearchUninstallKey()`. Extracted into a single `private static readonly string[] UninstallPaths` field referenced by both methods.

### ProgramItem.cs

`PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(...))` was written out twice inline in the `IsInstalled` setter. Extracted into a private `Notify(string name)` helper.

## TODO(AI) items

None.