### PR TITLE
feat!: modern-only platform floor, windows/linux parity and the crashes found getting there

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,9 @@ foreach (var instance in session.QueryInstances(
 | `Write-Host` for data/pipeline output | `Write-Output` or `return` | `Write-Host` bypasses the pipeline; only use it for user-facing display text |
 | String concatenation for paths (`"$dir\$file"`) | `Join-Path $dir $file` | Handles both `\` and `/` correctly on Windows and Linux |
 | Bare `ls`, `cat`, `cp` aliases | `Get-ChildItem`, `Get-Content`, `Copy-Item` | Aliases are unreliable in strict or non-interactive environments |
+| `(& somecmd args).Trim()` | `Get-PcCommandOutput 'somecmd' @('args')` | A missing or silent command returns `$null`, and `.Trim()` on it throws — which aborts the whole tool, not just that field. On Linux this is routine: no systemd in containers and WSL, no `mokutil`/`lspci` on minimal installs |
+| `sudo <cmd>` inside a tool | Call the command directly | pcHealth already exits unless it is running as root on Linux. Re-elevating is a no-op where sudo exists and a hard failure where it does not. `sudo -u <user>` to *drop* privileges is still correct |
+| `$env:USER` / `$env:HOME` on Linux | `Get-PcDesktopUser` | Under `sudo pwsh` both describe root, not the person at the keyboard |
 
 ### Bash (CLI Linux — `src/CLI/start.sh`)
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ pcHealth is a cross-platform toolkit for IT technicians and power users. It runs
 
 pcHealth targets current systems only and exits immediately below the minimum. Everything in that range boots UEFI with GPT, which is why the repair tools are UEFI-only and no MBR/CSM paths remain.
 
+On image-based systems (Fedora Silverblue, Bazzite, Kinoite, openSUSE MicroOS) the tools that manage packages or boot files are hidden rather than reimplemented: `/usr` is read-only and the bootloader belongs to the deployment, so `bootc` and `rpm-ostree` own that work. The other 14 Linux tools -- all the diagnostics -- run normally.
+
 - Windows release info: https://learn.microsoft.com/en-us/windows/release-health/windows11-release-information
 - Linux kernel releases: https://www.kernel.org/
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ Option numbers are assigned sequentially at runtime per platform - Windows-only 
 | Update all packages           | Linux     | apt / dnf / pacman / zypper                        |
 | Topgrade                      | Linux     | Full system upgrade: packages, flatpak, VS Code extensions, helm, uv, and more |
 | Battery Report                | Linux     | Laptop only - health, cycles, draw from sysfs      |
+| Scan + Repair                 | Linux     | Package integrity vs. package database             |
+| Disk Optimization             | Linux     | fstrim on SSDs; Linux needs no defragmenting       |
+| Firmware Update               | Linux     | fwupd / LVFS - BIOS, dock, SSD firmware            |
 | Disk Cleanup                  | Linux     | Package cache, journal logs, unused Flatpak runtimes, thumbnail cache |
 | Restart Audio                 | Linux     | Restarts PipeWire or PulseAudio user services      |
 | Reset Network Stack           | Linux     | Restarts NetworkManager, flushes DNS cache         |

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Option numbers are assigned sequentially at runtime per platform - Windows-only 
 | Function                      | Platforms | Notes                                              |
 |-------------------------------|-----------|----------------------------------------------------|
 | System Information            | All       | OS, kernel, firmware, TPM, RAM                     |
-| Hardware Information          | All       | CPU, GPU, Storage (SMART), RAM, Chipset            |
+| Hardware Information          | All       | CPU, GPU, Storage (SMART), RAM, Chipset, sensors   |
 | Scan + Repair                 | Windows   | SFC + DISM combined                                |
 | Battery Report                | Windows   | Laptop only                                        |
 | Windows Update                | Windows   | Opens Windows Update settings                      |
@@ -117,7 +117,9 @@ Option numbers are assigned sequentially at runtime per platform - Windows-only 
 | Traceroute to Google          | All       | tracert / traceroute                               |
 | Reset Network Stack           | Windows   | DNS flush, Winsock reset, IPv4/IPv6 reset          |
 | Update all packages           | Windows   | winget                                             |
+| Update all packages           | Linux     | apt / dnf / pacman / zypper                        |
 | Topgrade                      | Linux     | Full system upgrade: packages, flatpak, VS Code extensions, helm, uv, and more |
+| Battery Report                | Linux     | Laptop only - health, cycles, draw from sysfs      |
 | Disk Cleanup                  | Linux     | Package cache, journal logs, unused Flatpak runtimes, thumbnail cache |
 | Restart Audio                 | Linux     | Restarts PipeWire or PulseAudio user services      |
 | Reset Network Stack           | Linux     | Restarts NetworkManager, flushes DNS cache         |
@@ -131,7 +133,7 @@ Option numbers are assigned sequentially at runtime per platform - Windows-only 
 | Repair Boot Record            | Windows   | CHKDSK + SFC + BOOTREC - **use with caution**      |
 | Shutdown / Reboot / Log Off   | All       |                                                    |
 | Repair Winget                 | Windows   | via winget-install by @asheroto                    |
-| View System Logs              | Linux     | journalctl errors/warnings                         |
+| View System Logs              | Linux     | journalctl errors/warnings, failed units           |
 
 </details>
 
@@ -153,13 +155,15 @@ Option numbers are assigned sequentially at runtime per platform - Windows-only 
 <details>
 <summary><strong>Programs Menu - Linux</strong></summary>
 
-| Key | Program       | Install method     |
-|-----|---------------|--------------------|
-| 1   | htop          | apt / dnf / pacman |
-| 2   | iotop         | apt / dnf / pacman |
-| 3   | smartmontools | apt / dnf / pacman |
-| 4   | stress-ng     | apt / dnf / pacman |
-| 5   | nmap          | apt / dnf / pacman |
+Installed packages are marked `[installed]` in the menu.
+
+| Key | Program       | Install method              |
+|-----|---------------|-----------------------------|
+| 1   | htop          | apt / dnf / pacman / zypper |
+| 2   | iotop         | apt / dnf / pacman / zypper |
+| 3   | smartmontools | apt / dnf / pacman / zypper |
+| 4   | stress-ng     | apt / dnf / pacman / zypper |
+| 5   | nmap          | apt / dnf / pacman / zypper |
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ pcHealth is a cross-platform toolkit for IT technicians and power users. It runs
 
 ## Supported Platforms
 
-| Platform | CLI | GUI | Recommended          | Hard minimum        |
-|----------|-----|-----|----------------------|---------------------|
-| Windows  | ✅  | ✅ | Build 26200 (25H2+)  | Build 19045 (22H2)  |
-| Linux    | ✅  | ❌ | Kernel 7.0+          | Kernel 6.0          |
+| Platform | CLI | GUI | Minimum                       |
+|----------|-----|-----|-------------------------------|
+| Windows  | ✅  | ✅  | Build 26200 (Windows 11 25H2) |
+| Linux    | ✅  | ❌  | Kernel 7.0                    |
 
-Running below the recommended version shows a warning but does not block startup. Running below the hard minimum exits immediately.
+pcHealth targets current systems only and exits immediately below the minimum. Everything in that range boots UEFI with GPT, which is why the repair tools are UEFI-only and no MBR/CSM paths remain.
 
 - Windows release info: https://learn.microsoft.com/en-us/windows/release-health/windows11-release-information
 - Linux kernel releases: https://www.kernel.org/
@@ -37,7 +37,7 @@ See [SECURITY.md](SECURITY.md) for version and end-of-life details.
 
 ## Getting Started
 
-**Requirements:** PowerShell 7+, run as Administrator (Windows) or root/sudo (Linux). Recommended: Windows build 26200+ / Linux kernel 7.0+. Hard minimum: Windows build 19045 / kernel 6.0.
+**Requirements:** PowerShell 7+, run as Administrator (Windows) or root/sudo (Linux). Minimum: Windows build 26200 (11 25H2) or Linux kernel 7.0.
 
 ### Windows
 
@@ -61,7 +61,7 @@ sudo pwsh src/CLI/Start.ps1
 
 ### GUI
 
-On Windows, pcHealth includes a native desktop application built with **WinUI 3** (.NET 10). It provides the same functionality as the CLI in a graphical interface. Recommended: Windows build 26200 (25H2) or higher. Hard minimum: build 19045 (Windows 10 22H2).
+On Windows, pcHealth includes a native desktop application built with **WinUI 3** (.NET 10). It provides the same functionality as the CLI in a graphical interface. Minimum: build 26200 (Windows 11 25H2).
 
 A Linux GUI is not yet available - WinUI 3 is Windows-only. A cross-platform alternative is in the works.
 
@@ -123,6 +123,7 @@ Option numbers are assigned sequentially at runtime per platform - Windows-only 
 | Scan + Repair                 | Linux     | Package integrity vs. package database             |
 | Disk Optimization             | Linux     | fstrim on SSDs; Linux needs no defragmenting       |
 | Firmware Update               | Linux     | fwupd / LVFS - BIOS, dock, SSD firmware            |
+| Boot Repair                   | Linux     | systemd-boot / GRUB / Limine, UEFI - **care**      |
 | Disk Cleanup                  | Linux     | Package cache, journal logs, unused Flatpak runtimes, thumbnail cache |
 | Restart Audio                 | Linux     | Restarts PipeWire or PulseAudio user services      |
 | Reset Network Stack           | Linux     | Restarts NetworkManager, flushes DNS cache         |
@@ -133,7 +134,7 @@ Option numbers are assigned sequentially at runtime per platform - Windows-only 
 | Get Ninite                    | Windows   | Downloads Edge, Chrome, VLC, 7-Zip                 |
 | Windows License Key           | Windows   | OA3 + DigitalProductId registry decode             |
 | BIOS Password Recovery        | All       | Links to bios-pw.org - credits: @bacher09          |
-| Repair Boot Record            | Windows   | CHKDSK + SFC + BOOTREC - **use with caution**      |
+| Boot Repair                   | Windows   | CHKDSK + SFC + BCDBOOT, UEFI - **use with care**   |
 | Shutdown / Reboot / Log Off   | All       |                                                    |
 | Repair Winget                 | Windows   | via winget-install by @asheroto                    |
 | View System Logs              | Linux     | journalctl errors/warnings, failed units           |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,12 +4,12 @@
 
 The table below lists each supported platform, its recommended and hard minimum OS version, and its current support status within this project.
 
-| Platform | Recommended   | Hard minimum        | Status                 |
-|----------|---------------|---------------------|------------------------|
-| Windows  | Build 26200+  | Build 19045 (22H2)  | ✅ Actively maintained |
-| Linux    | Kernel 7.0+   | Kernel 6.0          | ✅ Actively maintained |
+| Platform | Minimum                       | Status                 |
+|----------|-------------------------------|------------------------|
+| Windows  | Build 26200 (Windows 11 25H2) | ✅ Actively maintained |
+| Linux    | Kernel 7.0                    | ✅ Actively maintained |
 
-Running below the recommended version shows a warning at startup but does not block the application. Running below the hard minimum exits immediately.
+Running below the minimum exits immediately; there is no warn-and-continue tier. Older releases are out of scope rather than best-effort: Windows 10 22H2 reached end of life in October 2025, and supporting pre-UEFI systems would mean carrying MBR/CSM repair paths that cannot be tested on any supported target.
 
 - Windows release info: https://learn.microsoft.com/en-us/windows/release-health/release-information
 - Windows 11 release info: https://learn.microsoft.com/en-us/windows/release-health/windows11-release-information
@@ -39,4 +39,4 @@ We aim to respond within **7 days** and will coordinate a fix and disclosure tim
 
 ## Scope
 
-These scripts run with administrator privileges and interact with the OS directly (SFC, DISM, network stack, boot record). Please treat any issues that could lead to privilege escalation, data loss, or unintended system modification as security-relevant.
+These scripts run with administrator privileges and interact with the OS directly (SFC, DISM, network stack, UEFI boot files). Please treat any issues that could lead to privilege escalation, data loss, or unintended system modification as security-relevant.

--- a/src/CLI/Start.ps1
+++ b/src/CLI/Start.ps1
@@ -164,9 +164,9 @@ if (-not $smartctlOk) {
     $answer = Read-Host $prompt
     if ($answer -match '^[Yy]') {
         if ($onLinux) {
-            if     (Get-Command apt-get -ErrorAction SilentlyContinue) { sudo apt-get install -y smartmontools }
-            elseif (Get-Command dnf     -ErrorAction SilentlyContinue) { sudo dnf install -y smartmontools }
-            elseif (Get-Command pacman  -ErrorAction SilentlyContinue) { sudo pacman -S --noconfirm smartmontools }
+            if     (Get-Command apt-get -ErrorAction SilentlyContinue) { apt-get install -y smartmontools }
+            elseif (Get-Command dnf     -ErrorAction SilentlyContinue) { dnf install -y smartmontools }
+            elseif (Get-Command pacman  -ErrorAction SilentlyContinue) { pacman -S --noconfirm smartmontools }
             else { Write-Host '[!!] No supported package manager found. Install smartmontools manually.' -ForegroundColor Yellow }
         } elseif (Get-Command winget -ErrorAction SilentlyContinue) {
             winget install --source winget --id smartmontools.smartmontools -e --silent `

--- a/src/CLI/Start.ps1
+++ b/src/CLI/Start.ps1
@@ -12,7 +12,9 @@ $isPwsh7 = $PSVersionTable.PSVersion.Major -ge 7
 
 # -- Linux: kernel version check + root guard ---------------------------------
 if ($onLinux) {
-    $kernelStr   = (& uname -r 2>$null).Trim()
+    # Start.ps1 runs before Helpers.ps1 is loaded, so guard the null here:
+    # calling .Trim() on a missing command's output throws before the check below.
+    $kernelStr   = "$(& uname -r 2>$null)".Trim()
     if (-not $kernelStr) {
         Write-Host "[!!] Could not determine kernel version (uname -r returned nothing)." -ForegroundColor Red
         Read-Host 'Press Enter to exit'
@@ -31,7 +33,7 @@ if ($onLinux) {
         Write-Host ""
     }
 
-    $isRoot = ((& id -u 2>$null).Trim() -eq '0')
+    $isRoot = ("$(& id -u 2>$null)".Trim() -eq '0')
     if (-not $isRoot) {
         Write-Host '[!!] pcHealth must be run as root on Linux.' -ForegroundColor Red
         Write-Host '     Run: sudo pwsh src/CLI/Start.ps1'       -ForegroundColor Yellow

--- a/src/CLI/Start.ps1
+++ b/src/CLI/Start.ps1
@@ -21,16 +21,12 @@ if ($onLinux) {
         exit 1
     }
     $kernelMajor = [int]($kernelStr -split '[.-]')[0]
-    if ($kernelMajor -lt 6) {
+    if ($kernelMajor -lt 7) {
         Write-Host "[!!] pcHealth cannot run on kernel $kernelStr." -ForegroundColor Red
-        Write-Host "     Minimum required: kernel 6.0." -ForegroundColor Red
+        Write-Host "     Minimum required: kernel 7.0." -ForegroundColor Red
+        Write-Host "     https://www.kernel.org/" -ForegroundColor DarkGray
         Read-Host 'Press Enter to exit'
         exit 1
-    } elseif ($kernelMajor -lt 7) {
-        Write-Host "[!] Your kernel ($kernelStr) is below the recommended version (7.0)." -ForegroundColor Yellow
-        Write-Host "    Some features may not work correctly. Consider updating your kernel." -ForegroundColor Yellow
-        Write-Host "    https://www.kernel.org/" -ForegroundColor DarkGray
-        Write-Host ""
     }
 
     $isRoot = ("$(& id -u 2>$null)".Trim() -eq '0')
@@ -44,17 +40,12 @@ if ($onLinux) {
 # -- Windows: build check, elevate, relaunch in PS7 ---------------------------
 if (-not $onLinux) {
     $build = [System.Environment]::OSVersion.Version.Build
-    if ($build -lt 19045) {
+    if ($build -lt 26200) {
         Write-Host "[!!] pcHealth cannot run on Windows build $build." -ForegroundColor Red
-        Write-Host "     Minimum required: build 19045 (Windows 10 version 22H2)." -ForegroundColor Red
+        Write-Host "     Minimum required: build 26200 (Windows 11 version 25H2)." -ForegroundColor Red
+        Write-Host "     https://learn.microsoft.com/en-us/windows/release-health/windows11-release-information" -ForegroundColor DarkGray
         Read-Host 'Press Enter to exit'
         exit 1
-    } elseif ($build -lt 26200) {
-        Write-Host "[!] Your Windows build ($build) is below the recommended version (26200 / Windows 11 25H2)." -ForegroundColor Yellow
-        Write-Host "    Some features may not work correctly. Consider updating Windows." -ForegroundColor Yellow
-        Write-Host "    https://learn.microsoft.com/en-us/windows/release-health/windows11-release-information" -ForegroundColor DarkGray
-        Write-Host "    https://learn.microsoft.com/en-us/windows/release-health/release-information" -ForegroundColor DarkGray
-        Write-Host ""
     }
 
     $isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(

--- a/src/CLI/app.ps1
+++ b/src/CLI/app.ps1
@@ -8,19 +8,13 @@ $ErrorActionPreference = 'Stop'
 
 # -- Platform detection + version guards ---------------------------------------
 if ($IsLinux) {
-    # Also checked in start.sh; repeated here as safety net for direct invocation.
-    # Hard minimum: kernel 6.0. Recommended: 7.0.
+    # Also checked in Start.ps1; repeated here as safety net for direct invocation.
     $kernelVersion = (uname -r)
     $kernelMajor   = [int]($kernelVersion -split '[\.\-]')[0]
-    if ($kernelMajor -lt 6) {
+    if ($kernelMajor -lt 7) {
         Write-Host "[!!] pcHealth cannot run on kernel $kernelVersion." -ForegroundColor Red
-        Write-Host "     Minimum required: kernel 6.0." -ForegroundColor Red
+        Write-Host "     Minimum required: kernel 7.0." -ForegroundColor Red
         exit 1
-    } elseif ($kernelMajor -lt 7) {
-        Write-Host "[!] Your kernel ($kernelVersion) is below the recommended version (7.0)." -ForegroundColor Yellow
-        Write-Host "    Some features may not work correctly. Consider updating your kernel." -ForegroundColor Yellow
-        Write-Host "    https://www.kernel.org/" -ForegroundColor DarkGray
-        Write-Host ""
     }
     # Also checked in Start.ps1; repeated here so tools can rely on being root
     # and call the package manager and systemctl directly, without sudo.
@@ -34,19 +28,12 @@ if ($IsLinux) {
     $Global:PcPlatformLabel = 'Linux'
 } elseif ($IsWindows) {
     # Also checked in Start.ps1 before elevation; repeated here as safety net.
-    # Hard minimum: build 19045 (Win 10 22H2). Recommended: 26200 (Win 11 25H2).
     $build = [System.Environment]::OSVersion.Version.Build
-    if ($build -lt 19045) {
+    if ($build -lt 26200) {
         Write-Host "[!!] pcHealth cannot run on Windows build $build." -ForegroundColor Red
-        Write-Host "     Minimum required: build 19045 (Windows 10 version 22H2)." -ForegroundColor Red
+        Write-Host "     Minimum required: build 26200 (Windows 11 version 25H2)." -ForegroundColor Red
         Write-Host "     Please upgrade your system." -ForegroundColor Yellow
         exit 1
-    } elseif ($build -lt 26200) {
-        Write-Host "[!] Your Windows build ($build) is below the recommended version (26200 / Windows 11 25H2)." -ForegroundColor Yellow
-        Write-Host "    Some features may not work correctly. Consider updating Windows." -ForegroundColor Yellow
-        Write-Host "    https://learn.microsoft.com/en-us/windows/release-health/windows11-release-information" -ForegroundColor DarkGray
-        Write-Host "    https://learn.microsoft.com/en-us/windows/release-health/release-information" -ForegroundColor DarkGray
-        Write-Host ""
     }
     $Global:PcPlatform      = 'Windows'
     $Global:PcPlatformLabel = 'Windows'

--- a/src/CLI/app.ps1
+++ b/src/CLI/app.ps1
@@ -22,6 +22,13 @@ if ($IsLinux) {
         Write-Host "    https://www.kernel.org/" -ForegroundColor DarkGray
         Write-Host ""
     }
+    # Also checked in Start.ps1; repeated here so tools can rely on being root
+    # and call the package manager and systemctl directly, without sudo.
+    if ("$(& id -u 2>$null)".Trim() -ne '0') {
+        Write-Host '[!!] pcHealth must be run as root on Linux.' -ForegroundColor Red
+        Write-Host '     Run: sudo pwsh src/CLI/Start.ps1'       -ForegroundColor Yellow
+        exit 1
+    }
     $Global:PcPlatform      = 'Linux'
     $Global:PcPlatformLabel = 'Linux'
 } elseif ($IsWindows) {

--- a/src/CLI/app.ps1
+++ b/src/CLI/app.ps1
@@ -24,7 +24,8 @@ if ($IsLinux) {
     }
     # Also checked in Start.ps1; repeated here so tools can rely on being root
     # and call the package manager and systemctl directly, without sudo.
-    if ("$(& id -u 2>$null)".Trim() -ne '0') {
+    $uid = "$(& id -u 2>$null)".Trim()
+    if ($uid -ne '0') {
         Write-Host '[!!] pcHealth must be run as root on Linux.' -ForegroundColor Red
         Write-Host '     Run: sudo pwsh src/CLI/Start.ps1'       -ForegroundColor Yellow
         exit 1

--- a/src/CLI/app.ps1
+++ b/src/CLI/app.ps1
@@ -70,6 +70,10 @@ $Global:PcVersion = if (Test-Path $versionFile) {
 
 # Order matters: Helpers must load before Main/Tools/Programs.
 . (Join-Path -Path $PSScriptRoot -ChildPath 'menus' -AdditionalChildPath 'Helpers.ps1')
+
+# Resolved once here: the Tools menu hides package- and boot-related tools on
+# image-based systems, where they cannot work.
+$Global:PcImageBased = Test-PcImageBasedSystem
 . (Join-Path -Path $PSScriptRoot -ChildPath 'menus' -AdditionalChildPath 'Main.ps1')
 . (Join-Path -Path $PSScriptRoot -ChildPath 'menus' -AdditionalChildPath 'Tools.ps1')
 . (Join-Path -Path $PSScriptRoot -ChildPath 'menus' -AdditionalChildPath 'Programs.ps1')

--- a/src/CLI/menus/Helpers.ps1
+++ b/src/CLI/menus/Helpers.ps1
@@ -54,23 +54,88 @@ function Get-PcDesktopUser {
     }
 }
 
+# True on image-based systems: Fedora Silverblue/Bazzite/Kinoite, openSUSE
+# MicroOS and friends. /usr is read-only there, so a traditional package
+# manager cannot change the running system even when it is installed.
+function Test-PcImageBasedSystem {
+    if (-not $IsLinux) { return $false }
+    return (Test-Path '/run/ostree-booted') -or (Test-Path '/ostree')
+}
+
 # Detects the distro's package manager and the verbs pcHealth needs from it.
-# Returns $null when none of the supported managers is present.
+# Returns $null when the distro has no manager pcHealth knows.
 # Refresh is $null where the update verb already syncs the package index.
 # Verify names its own command: rpm and debsums do the checking, not the manager.
+#
+# Chosen by distro family, NOT by which binary happens to be on PATH. A
+# Distrobox export or Homebrew readily puts apt and pacman on a Fedora box, and
+# picking the first one found would run Debian commands against an rpm system.
 function Get-PcPackageManager {
-    $managers = [ordered]@{
+    $definitions = @{
         'apt'    = @{ Refresh = @('update');  List = @('list', '--upgradable'); Update = @('upgrade', '-y');  Install = @('install', '-y');      Verify = @('debsums', '-s')  }
         'dnf'    = @{ Refresh = $null;        List = @('check-update');         Update = @('upgrade', '-y');  Install = @('install', '-y');      Verify = @('rpm', '-Va')     }
         'pacman' = @{ Refresh = @('-Sy');     List = @('-Qu');                  Update = @('-Syu', '--noconfirm'); Install = @('-S', '--noconfirm'); Verify = @('pacman', '-Qkk') }
         'zypper' = @{ Refresh = @('refresh'); List = @('list-updates');         Update = @('update', '-y');   Install = @('install', '-y');      Verify = @('rpm', '-Va')     }
     }
-    foreach ($cmd in $managers.Keys) {
-        if (Get-Command $cmd -CommandType Application -ErrorAction SilentlyContinue) {
-            return [PSCustomObject]($managers[$cmd] + @{ Cmd = $cmd })
+
+    # Image-based systems come first. Bazzite ships dnf, and Distrobox exports put
+    # apt and pacman on PATH too, but none of them can change a read-only /usr --
+    # the system is updated as a whole image instead.
+    if (Test-PcImageBasedSystem) {
+        # Prefer rpm-ostree where it exists. Images are moving to bootc, which
+        # updates the whole image but has no package or cleanup verbs at all --
+        # those come back as $null so callers can say so rather than guess.
+        if (Get-Command rpm-ostree -CommandType Application -ErrorAction SilentlyContinue) {
+            return [PSCustomObject]@{
+                Cmd     = 'rpm-ostree'
+                Atomic  = $true
+                Refresh = $null
+                List    = @('upgrade', '--preview')
+                Update  = @('upgrade')
+                Install = @('install', '-y')
+                # -b and -m clear temp files and cached metadata only. Never -r or
+                # -p: those delete the rollback and pending deployments, which are
+                # the whole safety net on an image-based system.
+                Clean   = @('cleanup', '-bm')
+                Verify  = @('ostree', 'fsck')
+            }
         }
+        if (Get-Command bootc -CommandType Application -ErrorAction SilentlyContinue) {
+            return [PSCustomObject]@{
+                Cmd     = 'bootc'
+                Atomic  = $true
+                Refresh = $null
+                List    = @('upgrade', '--check')
+                Update  = @('upgrade')
+                Install = $null
+                Clean   = $null
+                Verify  = $null
+            }
+        }
+        return $null
     }
-    return $null
+
+    $info   = Get-LinuxDistroInfo
+    $family = "$($info['ID']) $($info['ID_LIKE'])"
+
+    $name = switch -Regex ($family) {
+        'debian|ubuntu|mint|pop|elementary|zorin|kali' { 'apt';    break }
+        'fedora|rhel|centos|almalinux|rocky'           { 'dnf';    break }
+        'arch|cachyos|manjaro|endeavouros|artix'       { 'pacman'; break }
+        'suse|sles'                                    { 'zypper'; break }
+        default                                        { $null }
+    }
+
+    # Unrecognised distro: fall back to whatever is actually installed.
+    if (-not $name) {
+        $name = $definitions.Keys | Sort-Object |
+            Where-Object { Get-Command $_ -CommandType Application -ErrorAction SilentlyContinue } |
+            Select-Object -First 1
+    }
+    if (-not $name -or -not (Get-Command $name -CommandType Application -ErrorAction SilentlyContinue)) {
+        return $null
+    }
+    return [PSCustomObject]($definitions[$name] + @{ Cmd = $name; Atomic = $false })
 }
 
 # Opens a URL in the user's browser.

--- a/src/CLI/menus/Helpers.ps1
+++ b/src/CLI/menus/Helpers.ps1
@@ -3,6 +3,89 @@
 # Display and navigation utilities used by all menu scripts.
 # ============================================================================
 
+# Runs a native command and returns its trimmed output, or $null when the
+# command is missing, fails, or prints nothing.
+# The bare `(& cmd ...).Trim()` idiom throws on $null and aborts the whole tool.
+# On Linux that is the common case, not the edge case: containers and WSL have
+# no systemd (timedatectl, systemctl), and mokutil, lspci or uptime may not be
+# installed at all.
+function Get-PcCommandOutput {
+    param(
+        [Parameter(Mandatory, Position = 0)][string]$Command,
+        [Parameter(Position = 1)][string[]]$Arguments = @()
+    )
+    if (-not (Get-Command $Command -CommandType Application -ErrorAction SilentlyContinue)) { return $null }
+    $out = try { & $Command @Arguments 2>$null } catch { $null }
+    if (-not $out) { return $null }
+    $text = ($out -join "`n").Trim()
+    if ($text) { return $text } else { return $null }
+}
+
+# Resolves the human user behind the session. Under `sudo pwsh` the process
+# environment describes root, so tools that touch the desktop session -- audio,
+# topgrade, the thumbnail cache, log off -- must not use $env:USER or $env:HOME.
+# Returns $null on Windows and when no user can be determined.
+function Get-PcDesktopUser {
+    if (-not $IsLinux) { return $null }
+
+    $name = $env:SUDO_USER
+    if (-not $name) { $name = $env:USER }
+    # sudo -i clears both; ask the kernel who owns the login session instead.
+    if (-not $name) { $name = Get-PcCommandOutput 'id' @('-un') }
+    if (-not $name) { return $null }
+
+    $uid = Get-PcCommandOutput 'id' @('-u', $name)
+    # Field 6 of the passwd entry is the home directory.
+    $passwd  = Get-PcCommandOutput 'getent' @('passwd', $name)
+    $homeDir = if ($passwd) { ($passwd -split ':')[5] } else { $null }
+    if (-not $homeDir) { $homeDir = if ($name -eq 'root') { '/root' } else { "/home/$name" } }
+
+    # Session bus of the user's login session; needed by `systemctl --user`.
+    # The inherited address is passed on to `env` as key=value, so reject anything
+    # that is not a D-Bus transport and derive the standard path instead.
+    $dbus = $env:DBUS_SESSION_BUS_ADDRESS
+    if ($dbus -notmatch '^(unix|tcp|nonce-tcp|autolaunch):') { $dbus = "unix:path=/run/user/$uid/bus" }
+
+    [PSCustomObject]@{
+        Name = $name
+        Uid  = $uid
+        Home = $homeDir
+        Dbus = $dbus
+    }
+}
+
+# Opens a URL in the user's browser.
+# Start-Process cannot launch a URL on Linux -- it tries to exec it as a file --
+# so hand the address to xdg-open, and drop privileges so the browser lands in
+# the desktop session rather than root's.
+function Open-PcUrl {
+    param([Parameter(Mandatory)][string]$Url)
+    try {
+        if (-not $IsLinux) {
+            Start-Process $Url -ErrorAction Stop
+            return
+        }
+        $opener = @('xdg-open', 'gio', 'sensible-browser') |
+            Where-Object { Get-Command $_ -CommandType Application -ErrorAction SilentlyContinue } |
+            Select-Object -First 1
+        if (-not $opener) {
+            Write-Host "`n  Open this address manually: $Url" -ForegroundColor Yellow
+            return
+        }
+        $openArgs = if ($opener -eq 'gio') { @('open', $Url) } else { @($Url) }
+
+        $user = Get-PcDesktopUser
+        if ($user -and $user.Name -ne 'root') {
+            & sudo -u $user.Name env "DBUS_SESSION_BUS_ADDRESS=$($user.Dbus)" $opener @openArgs 2>&1 | Out-Null
+        } else {
+            & $opener @openArgs 2>&1 | Out-Null
+        }
+    } catch {
+        Write-Host "`n  [!!] Could not open browser: $_" -ForegroundColor Red
+        Write-Host "      Open this address manually: $Url" -ForegroundColor Yellow
+    }
+}
+
 # Write to both the console and a persistent log file under C:\pcHealth\Logs\ (Windows)
 # or ~/pcHealth/Logs/ (Linux).
 function Write-PcLog {

--- a/src/CLI/menus/Helpers.ps1
+++ b/src/CLI/menus/Helpers.ps1
@@ -55,8 +55,9 @@ function Get-PcDesktopUser {
 }
 
 # True on image-based systems: Fedora Silverblue/Bazzite/Kinoite, openSUSE
-# MicroOS and friends. /usr is read-only there, so a traditional package
-# manager cannot change the running system even when it is installed.
+# MicroOS and friends. /usr is read-only and the bootloader belongs to the
+# deployment, so tools that manage packages or boot files are hidden there
+# rather than taught a second dialect that would need chasing as bootc evolves.
 function Test-PcImageBasedSystem {
     if (-not $IsLinux) { return $false }
     return (Test-Path '/run/ostree-booted') -or (Test-Path '/ostree')
@@ -76,43 +77,6 @@ function Get-PcPackageManager {
         'dnf'    = @{ Refresh = $null;        List = @('check-update');         Update = @('upgrade', '-y');  Install = @('install', '-y');      Verify = @('rpm', '-Va')     }
         'pacman' = @{ Refresh = @('-Sy');     List = @('-Qu');                  Update = @('-Syu', '--noconfirm'); Install = @('-S', '--noconfirm'); Verify = @('pacman', '-Qkk') }
         'zypper' = @{ Refresh = @('refresh'); List = @('list-updates');         Update = @('update', '-y');   Install = @('install', '-y');      Verify = @('rpm', '-Va')     }
-    }
-
-    # Image-based systems come first. Bazzite ships dnf, and Distrobox exports put
-    # apt and pacman on PATH too, but none of them can change a read-only /usr --
-    # the system is updated as a whole image instead.
-    if (Test-PcImageBasedSystem) {
-        # Prefer rpm-ostree where it exists. Images are moving to bootc, which
-        # updates the whole image but has no package or cleanup verbs at all --
-        # those come back as $null so callers can say so rather than guess.
-        if (Get-Command rpm-ostree -CommandType Application -ErrorAction SilentlyContinue) {
-            return [PSCustomObject]@{
-                Cmd     = 'rpm-ostree'
-                Atomic  = $true
-                Refresh = $null
-                List    = @('upgrade', '--preview')
-                Update  = @('upgrade')
-                Install = @('install', '-y')
-                # -b and -m clear temp files and cached metadata only. Never -r or
-                # -p: those delete the rollback and pending deployments, which are
-                # the whole safety net on an image-based system.
-                Clean   = @('cleanup', '-bm')
-                Verify  = @('ostree', 'fsck')
-            }
-        }
-        if (Get-Command bootc -CommandType Application -ErrorAction SilentlyContinue) {
-            return [PSCustomObject]@{
-                Cmd     = 'bootc'
-                Atomic  = $true
-                Refresh = $null
-                List    = @('upgrade', '--check')
-                Update  = @('upgrade')
-                Install = $null
-                Clean   = $null
-                Verify  = $null
-            }
-        }
-        return $null
     }
 
     $info   = Get-LinuxDistroInfo
@@ -135,7 +99,7 @@ function Get-PcPackageManager {
     if (-not $name -or -not (Get-Command $name -CommandType Application -ErrorAction SilentlyContinue)) {
         return $null
     }
-    return [PSCustomObject]($definitions[$name] + @{ Cmd = $name; Atomic = $false })
+    return [PSCustomObject]($definitions[$name] + @{ Cmd = $name })
 }
 
 # Opens a URL in the user's browser.

--- a/src/CLI/menus/Helpers.ps1
+++ b/src/CLI/menus/Helpers.ps1
@@ -57,12 +57,13 @@ function Get-PcDesktopUser {
 # Detects the distro's package manager and the verbs pcHealth needs from it.
 # Returns $null when none of the supported managers is present.
 # Refresh is $null where the update verb already syncs the package index.
+# Verify names its own command: rpm and debsums do the checking, not the manager.
 function Get-PcPackageManager {
     $managers = [ordered]@{
-        'apt'    = @{ Refresh = @('update');  List = @('list', '--upgradable'); Update = @('upgrade', '-y');  Install = @('install', '-y')      }
-        'dnf'    = @{ Refresh = $null;        List = @('check-update');         Update = @('upgrade', '-y');  Install = @('install', '-y')      }
-        'pacman' = @{ Refresh = @('-Sy');     List = @('-Qu');                  Update = @('-Syu', '--noconfirm'); Install = @('-S', '--noconfirm') }
-        'zypper' = @{ Refresh = @('refresh'); List = @('list-updates');         Update = @('update', '-y');   Install = @('install', '-y')      }
+        'apt'    = @{ Refresh = @('update');  List = @('list', '--upgradable'); Update = @('upgrade', '-y');  Install = @('install', '-y');      Verify = @('debsums', '-s')  }
+        'dnf'    = @{ Refresh = $null;        List = @('check-update');         Update = @('upgrade', '-y');  Install = @('install', '-y');      Verify = @('rpm', '-Va')     }
+        'pacman' = @{ Refresh = @('-Sy');     List = @('-Qu');                  Update = @('-Syu', '--noconfirm'); Install = @('-S', '--noconfirm'); Verify = @('pacman', '-Qkk') }
+        'zypper' = @{ Refresh = @('refresh'); List = @('list-updates');         Update = @('update', '-y');   Install = @('install', '-y');      Verify = @('rpm', '-Va')     }
     }
     foreach ($cmd in $managers.Keys) {
         if (Get-Command $cmd -CommandType Application -ErrorAction SilentlyContinue) {

--- a/src/CLI/menus/Helpers.ps1
+++ b/src/CLI/menus/Helpers.ps1
@@ -54,6 +54,24 @@ function Get-PcDesktopUser {
     }
 }
 
+# Detects the distro's package manager and the verbs pcHealth needs from it.
+# Returns $null when none of the supported managers is present.
+# Refresh is $null where the update verb already syncs the package index.
+function Get-PcPackageManager {
+    $managers = [ordered]@{
+        'apt'    = @{ Refresh = @('update');  List = @('list', '--upgradable'); Update = @('upgrade', '-y');  Install = @('install', '-y')      }
+        'dnf'    = @{ Refresh = $null;        List = @('check-update');         Update = @('upgrade', '-y');  Install = @('install', '-y')      }
+        'pacman' = @{ Refresh = @('-Sy');     List = @('-Qu');                  Update = @('-Syu', '--noconfirm'); Install = @('-S', '--noconfirm') }
+        'zypper' = @{ Refresh = @('refresh'); List = @('list-updates');         Update = @('update', '-y');   Install = @('install', '-y')      }
+    }
+    foreach ($cmd in $managers.Keys) {
+        if (Get-Command $cmd -CommandType Application -ErrorAction SilentlyContinue) {
+            return [PSCustomObject]($managers[$cmd] + @{ Cmd = $cmd })
+        }
+    }
+    return $null
+}
+
 # Opens a URL in the user's browser.
 # Start-Process cannot launch a URL on Linux -- it tries to exec it as a file --
 # so hand the address to xdg-open, and drop privileges so the browser lands in
@@ -180,8 +198,9 @@ function Write-PcHeader {
         } else { $null }
     } catch { $null }
     if (-not $fullName) {
-        $fullName = if ($IsLinux) { $env:SUDO_USER ?? $env:USER } else { $env:USERNAME }
+        $fullName = if ($IsLinux) { (Get-PcDesktopUser)?.Name } else { $env:USERNAME }
     }
+    if (-not $fullName) { $fullName = 'there' }
     $now = Get-Date -Format 'dddd, dd MMMM yyyy  HH:mm'
     Write-Host "  Hello, $fullName!  *  $now`n" -ForegroundColor DarkGray
 }

--- a/src/CLI/menus/Main.ps1
+++ b/src/CLI/menus/Main.ps1
@@ -36,14 +36,8 @@ function Show-MainMenu {
             switch ($choice) {
                 '1' { $target = 'tools' }
                 '2' { $target = 'programs' }
-                '3' {
-                    try { Start-Process 'https://github.com/REALSDEALS/pcHealth' -ErrorAction Stop }
-                    catch { Write-Host "`n  [!!] Could not open browser: $_" -ForegroundColor Red; Start-Sleep 1 }
-                }
-                '4' {
-                    try { Start-Process 'https://github.com/REALSDEALS/pcHealth/releases' -ErrorAction Stop }
-                    catch { Write-Host "`n  [!!] Could not open browser: $_" -ForegroundColor Red; Start-Sleep 1 }
-                }
+                '3' { Open-PcUrl 'https://github.com/REALSDEALS/pcHealth' }
+                '4' { Open-PcUrl 'https://github.com/REALSDEALS/pcHealth/releases' }
                 '5' { $target = 'exit' }
                 default {
                     Write-Host "`n  Invalid choice." -ForegroundColor Red

--- a/src/CLI/menus/Programs.ps1
+++ b/src/CLI/menus/Programs.ps1
@@ -59,15 +59,6 @@ function Get-WingetResult {
     return @{ Ok = $false; Message = "Unexpected exit code ($hex)."; SuggestRepair = $true }
 }
 
-# Detects the available package manager on Linux.
-function Get-LinuxPackageManager {
-    if (Get-Command apt     -ErrorAction SilentlyContinue) { return @{ Cmd = 'apt';     Args = @('install', '-y') } }
-    if (Get-Command dnf     -ErrorAction SilentlyContinue) { return @{ Cmd = 'dnf';     Args = @('install', '-y') } }
-    if (Get-Command pacman  -ErrorAction SilentlyContinue) { return @{ Cmd = 'pacman';  Args = @('-S', '--noconfirm') } }
-    if (Get-Command zypper  -ErrorAction SilentlyContinue) { return @{ Cmd = 'zypper';  Args = @('install', '-y') } }
-    return $null
-}
-
 function Show-ProgramsMenu {
     if ($Global:PcPlatform -eq 'Linux') {
         Show-LinuxProgramsMenu
@@ -234,15 +225,21 @@ function Show-WindowsProgramsMenu {
 }
 
 function Show-LinuxProgramsMenu {
-    $pm = Get-LinuxPackageManager
+    $pm = Get-PcPackageManager
 
+    # Bin is what the menu probes for the [installed] marker: one PATH lookup,
+    # instead of a different "is this package present" query per manager.
     $packages = [ordered]@{
-        '1' = @{ Name = 'htop';          Pkg = 'htop'          }
-        '2' = @{ Name = 'iotop';         Pkg = 'iotop'         }
-        '3' = @{ Name = 'smartmontools'; Pkg = 'smartmontools'  }
-        '4' = @{ Name = 'stress-ng';     Pkg = 'stress-ng'     }
-        '5' = @{ Name = 'nmap';          Pkg = 'nmap'          }
+        '1' = @{ Name = 'htop';          Pkg = 'htop';          Bin = 'htop';      Note = '(process viewer)'  }
+        '2' = @{ Name = 'iotop';         Pkg = 'iotop';         Bin = 'iotop';     Note = '(I/O monitor)'     }
+        '3' = @{ Name = 'smartmontools'; Pkg = 'smartmontools'; Bin = 'smartctl';  Note = '(disk SMART data)' }
+        '4' = @{ Name = 'stress-ng';     Pkg = 'stress-ng';     Bin = 'stress-ng'; Note = '(stress test)'     }
+        '5' = @{ Name = 'nmap';          Pkg = 'nmap';          Bin = 'nmap';      Note = '(network scanner)' }
     }
+
+    $navTools = $packages.Count + 1
+    $navMain  = $packages.Count + 2
+    $navExit  = $packages.Count + 3
 
     while ($true) {
         Set-PcTheme 'Programs'
@@ -255,50 +252,57 @@ function Show-LinuxProgramsMenu {
             Write-Host "  [!] No supported package manager found (apt/dnf/pacman/zypper).`n" -ForegroundColor Yellow
         }
 
-        Write-PcOption '1' 'htop'          '(process viewer)'
-        Write-PcOption '2' 'iotop'         '(I/O monitor)'
-        Write-PcOption '3' 'smartmontools' '(disk SMART data)'
-        Write-PcOption '4' 'stress-ng'     '(stress test)'
-        Write-PcOption '5' 'nmap'          '(network scanner)'
+        foreach ($key in $packages.Keys) {
+            $p    = $packages[$key]
+            $note = if (Get-Command $p.Bin -CommandType Application -ErrorAction SilentlyContinue) {
+                "$($p.Note)  [installed]"
+            } else { $p.Note }
+            Write-PcOption $key $p.Name $note
+        }
+
         Write-PcDivider
-        Write-PcOption '6' 'Tools Menu'
-        Write-PcOption '7' 'Back to Main Menu'
-        Write-PcOption '8' 'Exit'
+        Write-PcOption "$navTools" 'Tools Menu'
+        Write-PcOption "$navMain"  'Back to Main Menu'
+        Write-PcOption "$navExit"  'Exit'
         Write-PcDivider
 
         $choice = (Read-Host "`n  Choice").Trim()
 
         switch ($choice) {
-            '6' { return 'tools' }
-            '7' { return 'main'  }
-            '8' { return 'exit'  }
+            "$navTools" { return 'tools' }
+            "$navMain"  { return 'main'  }
+            "$navExit"  { return 'exit'  }
         }
 
-        if ($packages.Contains($choice)) {
-            $pkg = $packages[$choice]
-            Set-PcTheme 'Action'
-            Clear-PcHost
-
-            if (-not $pm) {
-                Write-Host "[!!] No supported package manager found. Install $($pkg.Name) manually.`n" -ForegroundColor Red
-            } else {
-                Write-Host "[>>] Installing $($pkg.Name) via $($pm.Cmd)...`n" -ForegroundColor Yellow
-                & sudo $pm.Cmd $pm.Args $pkg.Pkg
-                if ($LASTEXITCODE -eq 0) {
-                    Write-Host "`n[OK] $($pkg.Name) installed." -ForegroundColor Green
-                } else {
-                    Write-Host "`n[!!] Installation returned exit code $LASTEXITCODE." -ForegroundColor Red
-                }
-            }
-
-            $nav = Read-PcNavChoice 'Back to Programs Menu'
-            switch ($nav) {
-                '2' { return 'main' }
-                '3' { return 'exit' }
-            }
-        } else {
+        if (-not $packages.Contains($choice)) {
             Write-Host "`n  Invalid choice." -ForegroundColor Red
             Start-Sleep -Milliseconds 800
+            continue
+        }
+
+        $pkg = $packages[$choice]
+        Set-PcTheme 'Action'
+        Clear-PcHost
+
+        if (Get-Command $pkg.Bin -CommandType Application -ErrorAction SilentlyContinue) {
+            Write-Host "[OK] $($pkg.Name) is already installed." -ForegroundColor Green
+            Write-Host "     Update it via Tools > Update all packages.`n" -ForegroundColor DarkGray
+        } elseif (-not $pm) {
+            Write-Host "[!!] No supported package manager found. Install $($pkg.Name) manually.`n" -ForegroundColor Red
+        } else {
+            Write-Host "[>>] Installing $($pkg.Name) via $($pm.Cmd)...`n" -ForegroundColor Yellow
+            & $pm.Cmd @($pm.Install) $pkg.Pkg
+            if ($LASTEXITCODE -eq 0) {
+                Write-Host "`n[OK] $($pkg.Name) installed." -ForegroundColor Green
+            } else {
+                Write-Host "`n[!!] Installation returned exit code $LASTEXITCODE." -ForegroundColor Red
+            }
+        }
+
+        $nav = Read-PcNavChoice 'Back to Programs Menu'
+        switch ($nav) {
+            '2' { return 'main' }
+            '3' { return 'exit' }
         }
     }
 }

--- a/src/CLI/menus/Programs.ps1
+++ b/src/CLI/menus/Programs.ps1
@@ -246,7 +246,11 @@ function Show-LinuxProgramsMenu {
         Clear-PcHost
         Write-PcHeader 'Programs'
 
-        if ($pm) {
+        if ($pm -and $pm.Atomic) {
+            Write-Host "  Package manager: $($pm.Cmd)  (image-based)" -ForegroundColor DarkGray
+            Write-Host '  Installing here layers the package into the image and needs a' -ForegroundColor DarkGray
+            Write-Host "  reboot. Homebrew or a Distrobox container is usually better.`n" -ForegroundColor DarkGray
+        } elseif ($pm) {
             Write-Host "  Package manager: $($pm.Cmd)`n" -ForegroundColor DarkGray
         } else {
             Write-Host "  [!] No supported package manager found (apt/dnf/pacman/zypper).`n" -ForegroundColor Yellow
@@ -287,13 +291,17 @@ function Show-LinuxProgramsMenu {
         if (Get-Command $pkg.Bin -CommandType Application -ErrorAction SilentlyContinue) {
             Write-Host "[OK] $($pkg.Name) is already installed." -ForegroundColor Green
             Write-Host "     Update it via Tools > Update all packages.`n" -ForegroundColor DarkGray
-        } elseif (-not $pm) {
-            Write-Host "[!!] No supported package manager found. Install $($pkg.Name) manually.`n" -ForegroundColor Red
+        } elseif (-not $pm -or -not $pm.Install) {
+            Write-Host "[!!] This system has no package install command pcHealth can use." -ForegroundColor Red
+            Write-Host "     Install $($pkg.Name) with Homebrew or inside a Distrobox container.`n" -ForegroundColor Yellow
         } else {
             Write-Host "[>>] Installing $($pkg.Name) via $($pm.Cmd)...`n" -ForegroundColor Yellow
             & $pm.Cmd @($pm.Install) $pkg.Pkg
             if ($LASTEXITCODE -eq 0) {
                 Write-Host "`n[OK] $($pkg.Name) installed." -ForegroundColor Green
+                if ($pm.Atomic) {
+                    Write-Host '     Layered into a new deployment -- reboot to use it.' -ForegroundColor Yellow
+                }
             } else {
                 Write-Host "`n[!!] Installation returned exit code $LASTEXITCODE." -ForegroundColor Red
             }

--- a/src/CLI/menus/Programs.ps1
+++ b/src/CLI/menus/Programs.ps1
@@ -246,10 +246,9 @@ function Show-LinuxProgramsMenu {
         Clear-PcHost
         Write-PcHeader 'Programs'
 
-        if ($pm -and $pm.Atomic) {
-            Write-Host "  Package manager: $($pm.Cmd)  (image-based)" -ForegroundColor DarkGray
-            Write-Host '  Installing here layers the package into the image and needs a' -ForegroundColor DarkGray
-            Write-Host "  reboot. Homebrew or a Distrobox container is usually better.`n" -ForegroundColor DarkGray
+        if ($Global:PcImageBased) {
+            Write-Host '  Image-based system: pcHealth does not install packages here.' -ForegroundColor DarkGray
+            Write-Host "  Use Homebrew or a Distrobox container instead.`n" -ForegroundColor DarkGray
         } elseif ($pm) {
             Write-Host "  Package manager: $($pm.Cmd)`n" -ForegroundColor DarkGray
         } else {
@@ -291,17 +290,14 @@ function Show-LinuxProgramsMenu {
         if (Get-Command $pkg.Bin -CommandType Application -ErrorAction SilentlyContinue) {
             Write-Host "[OK] $($pkg.Name) is already installed." -ForegroundColor Green
             Write-Host "     Update it via Tools > Update all packages.`n" -ForegroundColor DarkGray
-        } elseif (-not $pm -or -not $pm.Install) {
-            Write-Host "[!!] This system has no package install command pcHealth can use." -ForegroundColor Red
+        } elseif ($Global:PcImageBased -or -not $pm) {
+            Write-Host '[!!] pcHealth does not install packages on an image-based system.' -ForegroundColor Red
             Write-Host "     Install $($pkg.Name) with Homebrew or inside a Distrobox container.`n" -ForegroundColor Yellow
         } else {
             Write-Host "[>>] Installing $($pkg.Name) via $($pm.Cmd)...`n" -ForegroundColor Yellow
             & $pm.Cmd @($pm.Install) $pkg.Pkg
             if ($LASTEXITCODE -eq 0) {
                 Write-Host "`n[OK] $($pkg.Name) installed." -ForegroundColor Green
-                if ($pm.Atomic) {
-                    Write-Host '     Layered into a new deployment -- reboot to use it.' -ForegroundColor Yellow
-                }
             } else {
                 Write-Host "`n[!!] Installation returned exit code $LASTEXITCODE." -ForegroundColor Red
             }

--- a/src/CLI/menus/Tools.ps1
+++ b/src/CLI/menus/Tools.ps1
@@ -30,7 +30,9 @@ function Show-ToolsMenu {
         @{ Label = 'Repair Boot Record';           Script = 'Invoke-BootRepair.ps1';         Note = '(use with caution!)';   Platforms = @('Windows') }
         @{ Label = 'Shutdown / Reboot / Log Off';  Script = 'Invoke-PowerOptions.ps1';       Note = '';                      Platforms = @('Windows','Linux') }
         @{ Label = 'Repair Winget';                Script = 'Invoke-WingetRepair.ps1';       Note = '';                      Platforms = @('Windows') }
+        @{ Label = 'Update all packages';          Script = 'linux/Invoke-SystemUpdate.ps1';  Note = '(apt / dnf / pacman / zypper)';   Platforms = @('Linux') }
         @{ Label = 'Topgrade';                     Script = 'linux/Invoke-Topgrade.ps1';       Note = '(full system upgrade)';           Platforms = @('Linux') }
+        @{ Label = 'Battery Report';               Script = 'linux/Get-BatteryReport.ps1';     Note = '(laptop only)';                   Platforms = @('Linux') }
         @{ Label = 'Disk Cleanup';                 Script = 'linux/Invoke-DiskCleanup.ps1';   Note = '(cache, journal, flatpak)';       Platforms = @('Linux') }
         @{ Label = 'Restart Audio';                Script = 'linux/Invoke-AudioRestart.ps1';  Note = '(PipeWire / PulseAudio)';         Platforms = @('Linux') }
         @{ Label = 'Reset Network Stack';          Script = 'linux/Invoke-NetworkReset.ps1';  Note = '';                                Platforms = @('Linux') }

--- a/src/CLI/menus/Tools.ps1
+++ b/src/CLI/menus/Tools.ps1
@@ -33,6 +33,9 @@ function Show-ToolsMenu {
         @{ Label = 'Update all packages';          Script = 'linux/Invoke-SystemUpdate.ps1';  Note = '(apt / dnf / pacman / zypper)';   Platforms = @('Linux') }
         @{ Label = 'Topgrade';                     Script = 'linux/Invoke-Topgrade.ps1';       Note = '(full system upgrade)';           Platforms = @('Linux') }
         @{ Label = 'Battery Report';               Script = 'linux/Get-BatteryReport.ps1';     Note = '(laptop only)';                   Platforms = @('Linux') }
+        @{ Label = 'Scan + Repair';                Script = 'linux/Invoke-ScanAndRepair.ps1';  Note = '(package integrity)';             Platforms = @('Linux') }
+        @{ Label = 'Disk Optimization';            Script = 'linux/Invoke-DiskOptimize.ps1';   Note = '(SSD trim)';                      Platforms = @('Linux') }
+        @{ Label = 'Firmware Update';              Script = 'linux/Invoke-FirmwareUpdate.ps1'; Note = '(fwupd / LVFS)';                  Platforms = @('Linux') }
         @{ Label = 'Disk Cleanup';                 Script = 'linux/Invoke-DiskCleanup.ps1';   Note = '(cache, journal, flatpak)';       Platforms = @('Linux') }
         @{ Label = 'Restart Audio';                Script = 'linux/Invoke-AudioRestart.ps1';  Note = '(PipeWire / PulseAudio)';         Platforms = @('Linux') }
         @{ Label = 'Reset Network Stack';          Script = 'linux/Invoke-NetworkReset.ps1';  Note = '';                                Platforms = @('Linux') }

--- a/src/CLI/menus/Tools.ps1
+++ b/src/CLI/menus/Tools.ps1
@@ -27,7 +27,7 @@ function Show-ToolsMenu {
         @{ Label = 'Get Ninite';                   Script = 'Get-Ninite.ps1';                Note = '(Edge, Chrome, VLC, 7-Zip)'; Platforms = @('Windows') }
         @{ Label = 'Windows License Key';          Script = 'Get-LicenseKey.ps1';            Note = '';                      Platforms = @('Windows') }
         @{ Label = 'BIOS Password Recovery';       Script = 'Open-BIOSPasswordTool.ps1';     Note = '';                      Platforms = @('Windows','Linux') }
-        @{ Label = 'Repair Boot Record';           Script = 'Invoke-BootRepair.ps1';         Note = '(use with caution!)';   Platforms = @('Windows') }
+        @{ Label = 'Boot Repair';                  Script = 'Invoke-BootRepair.ps1';         Note = '(UEFI - caution!)';     Platforms = @('Windows') }
         @{ Label = 'Shutdown / Reboot / Log Off';  Script = 'Invoke-PowerOptions.ps1';       Note = '';                      Platforms = @('Windows','Linux') }
         @{ Label = 'Repair Winget';                Script = 'Invoke-WingetRepair.ps1';       Note = '';                      Platforms = @('Windows') }
         @{ Label = 'Update all packages';          Script = 'linux/Invoke-SystemUpdate.ps1';  Note = '(apt / dnf / pacman / zypper)';   Platforms = @('Linux') }
@@ -36,6 +36,7 @@ function Show-ToolsMenu {
         @{ Label = 'Scan + Repair';                Script = 'linux/Invoke-ScanAndRepair.ps1';  Note = '(package integrity)';             Platforms = @('Linux') }
         @{ Label = 'Disk Optimization';            Script = 'linux/Invoke-DiskOptimize.ps1';   Note = '(SSD trim)';                      Platforms = @('Linux') }
         @{ Label = 'Firmware Update';              Script = 'linux/Invoke-FirmwareUpdate.ps1'; Note = '(fwupd / LVFS)';                  Platforms = @('Linux') }
+        @{ Label = 'Boot Repair';                  Script = 'linux/Invoke-BootRepair.ps1';     Note = '(UEFI - caution!)';               Platforms = @('Linux') }
         @{ Label = 'Disk Cleanup';                 Script = 'linux/Invoke-DiskCleanup.ps1';   Note = '(cache, journal, flatpak)';       Platforms = @('Linux') }
         @{ Label = 'Restart Audio';                Script = 'linux/Invoke-AudioRestart.ps1';  Note = '(PipeWire / PulseAudio)';         Platforms = @('Linux') }
         @{ Label = 'Reset Network Stack';          Script = 'linux/Invoke-NetworkReset.ps1';  Note = '';                                Platforms = @('Linux') }

--- a/src/CLI/menus/Tools.ps1
+++ b/src/CLI/menus/Tools.ps1
@@ -6,7 +6,9 @@
 
 function Show-ToolsMenu {
     # Each entry: Label, Script (relative to tools/), Note, Platforms.
-    # Platforms controls which OS sees the option.
+    # Platforms controls which OS sees the option. NeedsMutableOS hides an entry
+    # on image-based systems (Silverblue, Bazzite, MicroOS), where /usr is
+    # read-only and the bootloader belongs to the deployment.
     $toolDefs = @(
         @{ Label = 'System Information';          Script = 'Get-SystemInfo.ps1';          Note = '';                      Platforms = @('Windows','Linux') }
         @{ Label = 'Hardware Information';         Script = 'Get-HardwareInfo.ps1';         Note = '';                      Platforms = @('Windows','Linux') }
@@ -30,20 +32,23 @@ function Show-ToolsMenu {
         @{ Label = 'Boot Repair';                  Script = 'Invoke-BootRepair.ps1';         Note = '(UEFI - caution!)';     Platforms = @('Windows') }
         @{ Label = 'Shutdown / Reboot / Log Off';  Script = 'Invoke-PowerOptions.ps1';       Note = '';                      Platforms = @('Windows','Linux') }
         @{ Label = 'Repair Winget';                Script = 'Invoke-WingetRepair.ps1';       Note = '';                      Platforms = @('Windows') }
-        @{ Label = 'Update all packages';          Script = 'linux/Invoke-SystemUpdate.ps1';  Note = '(apt / dnf / pacman / zypper)';   Platforms = @('Linux') }
+        @{ Label = 'Update all packages';          Script = 'linux/Invoke-SystemUpdate.ps1';  Note = '(apt / dnf / pacman / zypper)';   Platforms = @('Linux'); NeedsMutableOS = $true }
         @{ Label = 'Topgrade';                     Script = 'linux/Invoke-Topgrade.ps1';       Note = '(full system upgrade)';           Platforms = @('Linux') }
         @{ Label = 'Battery Report';               Script = 'linux/Get-BatteryReport.ps1';     Note = '(laptop only)';                   Platforms = @('Linux') }
-        @{ Label = 'Scan + Repair';                Script = 'linux/Invoke-ScanAndRepair.ps1';  Note = '(package integrity)';             Platforms = @('Linux') }
+        @{ Label = 'Scan + Repair';                Script = 'linux/Invoke-ScanAndRepair.ps1';  Note = '(package integrity)';             Platforms = @('Linux'); NeedsMutableOS = $true }
         @{ Label = 'Disk Optimization';            Script = 'linux/Invoke-DiskOptimize.ps1';   Note = '(SSD trim)';                      Platforms = @('Linux') }
         @{ Label = 'Firmware Update';              Script = 'linux/Invoke-FirmwareUpdate.ps1'; Note = '(fwupd / LVFS)';                  Platforms = @('Linux') }
-        @{ Label = 'Boot Repair';                  Script = 'linux/Invoke-BootRepair.ps1';     Note = '(UEFI - caution!)';               Platforms = @('Linux') }
-        @{ Label = 'Disk Cleanup';                 Script = 'linux/Invoke-DiskCleanup.ps1';   Note = '(cache, journal, flatpak)';       Platforms = @('Linux') }
+        @{ Label = 'Boot Repair';                  Script = 'linux/Invoke-BootRepair.ps1';     Note = '(UEFI - caution!)';               Platforms = @('Linux'); NeedsMutableOS = $true }
+        @{ Label = 'Disk Cleanup';                 Script = 'linux/Invoke-DiskCleanup.ps1';   Note = '(cache, journal, flatpak)';       Platforms = @('Linux'); NeedsMutableOS = $true }
         @{ Label = 'Restart Audio';                Script = 'linux/Invoke-AudioRestart.ps1';  Note = '(PipeWire / PulseAudio)';         Platforms = @('Linux') }
         @{ Label = 'Reset Network Stack';          Script = 'linux/Invoke-NetworkReset.ps1';  Note = '';                                Platforms = @('Linux') }
         @{ Label = 'View System Logs';             Script = 'linux/Get-SystemLogs.ps1';       Note = '(journalctl)';                    Platforms = @('Linux') }
     )
 
-    $active = @($toolDefs | Where-Object { $_.Platforms -contains $Global:PcPlatform })
+    $active = @($toolDefs | Where-Object {
+        $_.Platforms -contains $Global:PcPlatform -and
+        -not ($_.NeedsMutableOS -and $Global:PcImageBased)
+    })
     $t      = Join-Path $Global:pcHealthRoot 'tools'
 
     while ($true) {

--- a/src/CLI/tools/Get-HardwareInfo.ps1
+++ b/src/CLI/tools/Get-HardwareInfo.ps1
@@ -166,6 +166,37 @@ if ($IsLinux) {
         Write-Warning "RAM information not available."
     }
 
+    # -- Sensors --------------------------------------------------------------
+    # Straight from the kernel's hwmon class -- the same source lm-sensors reads,
+    # so no package needs to be installed.
+    Write-SectionHeader 'Sensors (Temperatures)'
+    $hwmonRoot = '/sys/class/hwmon'
+    $readings  = @(
+        if (Test-Path $hwmonRoot) {
+            foreach ($chip in Get-ChildItem $hwmonRoot -ErrorAction SilentlyContinue) {
+                $chipName = try { (Get-Content (Join-Path $chip.FullName 'name') -Raw -ErrorAction Stop).Trim() }
+                            catch { $chip.Name }
+                foreach ($sensor in Get-ChildItem $chip.FullName -Filter 'temp*_input' -ErrorAction SilentlyContinue) {
+                    $milli = try { [double](Get-Content $sensor.FullName -Raw -ErrorAction Stop) } catch { continue }
+                    $labelFile = $sensor.FullName -replace '_input$', '_label'
+                    $label = if (Test-Path $labelFile) {
+                        (Get-Content $labelFile -Raw -ErrorAction SilentlyContinue).Trim()
+                    } else { $sensor.Name -replace '_input$', '' }
+                    [PSCustomObject]@{
+                        Chip       = $chipName
+                        Sensor     = $label
+                        'Temp (C)' = [Math]::Round($milli / 1000, 1)
+                    }
+                }
+            }
+        }
+    )
+    if ($readings) {
+        $readings | Sort-Object Chip, Sensor | Format-Table -AutoSize | Out-Host
+    } else {
+        Write-Warning "No temperature sensors exposed under $hwmonRoot."
+    }
+
 } else {
     # -- CPU (Windows) --------------------------------------------------------
     $cpuData = Get-CimInstance -ClassName Win32_Processor -ErrorAction SilentlyContinue

--- a/src/CLI/tools/Get-HardwareInfo.ps1
+++ b/src/CLI/tools/Get-HardwareInfo.ps1
@@ -31,7 +31,9 @@ if (-not $smartctl) {
     if ($answer -match '^[Yy]') {
         if ($IsLinux) {
             $pm = Get-PcPackageManager
-            if ($pm) { & $pm.Cmd @($pm.Install) smartmontools }
+            if ($Global:PcImageBased) {
+                Write-Host '[!!] Image-based system -- install smartmontools with Homebrew or Distrobox.' -ForegroundColor Yellow
+            } elseif ($pm) { & $pm.Cmd @($pm.Install) smartmontools }
             else { Write-Host '[!!] No supported package manager found. Install smartmontools manually.' -ForegroundColor Yellow }
         } else {
             if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {

--- a/src/CLI/tools/Get-HardwareInfo.ps1
+++ b/src/CLI/tools/Get-HardwareInfo.ps1
@@ -30,11 +30,9 @@ if (-not $smartctl) {
     $answer = (Read-Host $prompt).Trim()
     if ($answer -match '^[Yy]') {
         if ($IsLinux) {
-            $pm = if (Get-Command apt-get -EA SilentlyContinue) { @('apt-get','install','-y','smartmontools') }
-                  elseif (Get-Command dnf  -EA SilentlyContinue) { @('dnf','install','-y','smartmontools')     }
-                  elseif (Get-Command pacman -EA SilentlyContinue) { @('pacman','-S','--noconfirm','smartmontools') }
-                  else { $null }
-            if ($pm) { & sudo $pm[0] $pm[1..($pm.Count-1)] } else { Write-Host '[!!] No supported package manager found. Install smartmontools manually.' -ForegroundColor Yellow }
+            $pm = Get-PcPackageManager
+            if ($pm) { & $pm.Cmd @($pm.Install) smartmontools }
+            else { Write-Host '[!!] No supported package manager found. Install smartmontools manually.' -ForegroundColor Yellow }
         } else {
             if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
                 Write-Host '[!!] winget not available. Install from: https://www.smartmontools.org/' -ForegroundColor Yellow

--- a/src/CLI/tools/Get-SystemInfo.ps1
+++ b/src/CLI/tools/Get-SystemInfo.ps1
@@ -5,10 +5,10 @@
 
 if ($IsLinux) {
     $hostname  = [System.Net.Dns]::GetHostName()
-    $kernel    = (& uname -r 2>$null).Trim()
-    $arch      = (& uname -m 2>$null).Trim()
-    $uptime    = (& 'uptime' -p 2>$null).Trim()
-    $user      = $env:USER ?? $env:USERNAME
+    $kernel    = (Get-PcCommandOutput 'uname'  @('-r')) ?? 'N/A'
+    $arch      = (Get-PcCommandOutput 'uname'  @('-m')) ?? 'N/A'
+    $uptime    = (Get-PcCommandOutput 'uptime' @('-p')) ?? 'N/A'
+    $user      = (Get-PcDesktopUser)?.Name     ?? 'N/A'
 
     $osName = (Get-LinuxDistroInfo)['PRETTY_NAME']
 
@@ -43,8 +43,8 @@ if ($IsLinux) {
 
     # Secure Boot
     $secureBoot = 'N/A'
-    if (Get-Command mokutil -ErrorAction SilentlyContinue) {
-        $mokOut = (& mokutil --sb-state 2>$null).Trim()
+    $mokOut = Get-PcCommandOutput 'mokutil' @('--sb-state')
+    if ($mokOut) {
         $secureBoot = if ($mokOut -match 'enabled') { 'Enabled' } elseif ($mokOut -match 'disabled') { 'Disabled' } else { $mokOut }
     } elseif (Test-Path '/sys/firmware/efi/efivars') {
         $sbVar = Get-ChildItem '/sys/firmware/efi/efivars' -Filter 'SecureBoot-*' -ErrorAction SilentlyContinue | Select-Object -First 1
@@ -60,8 +60,7 @@ if ($IsLinux) {
     }
 
     # Last boot timestamp
-    $lastBoot = (& uptime -s 2>$null).Trim()
-    if (-not $lastBoot) { $lastBoot = 'N/A' }
+    $lastBoot = (Get-PcCommandOutput 'uptime' @('-s')) ?? 'N/A'
 
     # Desktop environment / Wayland or X11
     $de      = $env:XDG_CURRENT_DESKTOP ?? $env:DESKTOP_SESSION ?? 'Unknown'
@@ -82,8 +81,9 @@ if ($IsLinux) {
     }
 
     # Timezone
-    $timezone = (& timedatectl show --property=Timezone --value 2>$null).Trim()
-    if (-not $timezone) { $timezone = $env:TZ ?? (& date '+%Z' 2>$null).Trim() ?? 'N/A' }
+    # timedatectl is unavailable without systemd (containers, WSL, OpenRC distros).
+    $timezone = Get-PcCommandOutput 'timedatectl' @('show', '--property=Timezone', '--value')
+    if (-not $timezone) { $timezone = $env:TZ ?? (Get-PcCommandOutput 'date' @('+%Z')) ?? 'N/A' }
 
     [PSCustomObject]@{
         'Computer Name'  = $hostname

--- a/src/CLI/tools/Invoke-BootRepair.ps1
+++ b/src/CLI/tools/Invoke-BootRepair.ps1
@@ -99,20 +99,33 @@ if (-not $windir) {
     Write-Warning "Windows partition not found -- cannot rebuild the boot files."
 } else {
     # The EFI System Partition normally has no drive letter; mountvol /S assigns
-    # one so bcdboot can write to it.
-    & mountvol.exe S: /S
-    if (Test-Path 'S:\') {
-        # /f UEFI, not /f ALL: ALL also writes BIOS boot files, which nothing in
-        # the supported range boots from.
-        & bcdboot.exe $windir /s S: /f UEFI
-        if ($LASTEXITCODE -eq 0) {
-            Write-Host "[OK] EFI boot files rewritten.`n" -ForegroundColor Green
-        } else {
-            Write-Warning "bcdboot exited with code $LASTEXITCODE."
-        }
-        & mountvol.exe S: /D
+    # one so bcdboot can write to it. Pick a letter that is genuinely free --
+    # hardcoding S: and testing Test-Path afterwards would silently target
+    # whatever was already mounted there and then dismount the user's drive.
+    $espLetter = 68..90 | ForEach-Object { [char]$_ } |
+        Where-Object { -not (Test-Path "${_}:\") } | Select-Object -First 1
+
+    if (-not $espLetter) {
+        Write-Warning "No free drive letter available to mount the EFI System Partition."
     } else {
-        Write-Warning "Could not mount the EFI System Partition. Manual intervention may be required."
+        & mountvol.exe "${espLetter}:" /S
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "Could not mount the EFI System Partition (mountvol exit $LASTEXITCODE)."
+        } else {
+            try {
+                # /f UEFI, not /f ALL: ALL also writes BIOS boot files, which
+                # nothing in the supported range boots from.
+                & bcdboot.exe $windir /s "${espLetter}:" /f UEFI
+                if ($LASTEXITCODE -eq 0) {
+                    Write-Host "[OK] EFI boot files rewritten.`n" -ForegroundColor Green
+                } else {
+                    Write-Warning "bcdboot exited with code $LASTEXITCODE."
+                }
+            } finally {
+                # Always release the ESP, even if bcdboot threw.
+                & mountvol.exe "${espLetter}:" /D
+            }
+        }
     }
 }
 

--- a/src/CLI/tools/Invoke-BootRepair.ps1
+++ b/src/CLI/tools/Invoke-BootRepair.ps1
@@ -1,8 +1,14 @@
 ﻿#Requires -Version 7.0
 # ============================================================================
-# pcHealth -- Boot Record Repair
-# Attempts to repair the boot record via CHKDSK, SFC, BOOTREC and BCDBOOT.
+# pcHealth -- Boot Repair (UEFI)
+# Repairs the EFI boot files via CHKDSK, SFC and BCDBOOT.
 # Best run from a recovery environment (WinRE/CMD) with Administrator rights.
+#
+# UEFI only. Windows 11 requires UEFI + GPT and pcHealth's minimum is build
+# 26200, so every supported system boots UEFI. The old bootrec /fixmbr and
+# /fixboot steps wrote MBR-era boot code that nothing on a GPT disk reads --
+# /fixboot in fact returns "Access is denied" on EFI systems, which is why the
+# real repair was always the bcdboot fallback underneath it.
 # ============================================================================
 
 if (Get-Command Set-PcTheme -ErrorAction SilentlyContinue) {
@@ -11,11 +17,27 @@ if (Get-Command Set-PcTheme -ErrorAction SilentlyContinue) {
 }
 
 Write-Host "`n$('=' * 60)" -ForegroundColor Red
-Write-Host "  Boot Record Repair" -ForegroundColor Red
+Write-Host "  Boot Repair  (UEFI)" -ForegroundColor Red
 Write-Host "$('=' * 60)`n" -ForegroundColor Red
 Write-Host "  WARNING: This operation modifies boot-critical files." -ForegroundColor Yellow
 Write-Host "  Incorrect use can render the system unbootable." -ForegroundColor Yellow
 Write-Host "  Only proceed if you understand what you are doing.`n" -ForegroundColor Yellow
+
+# PEFirmwareType: 1 = legacy BIOS, 2 = UEFI. Refuse rather than guess -- the
+# repair below writes EFI boot files, which do nothing on a BIOS/MBR install.
+$firmwareType = try {
+    (Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control' -Name PEFirmwareType -ErrorAction Stop).PEFirmwareType
+} catch {
+    Write-Debug "PEFirmwareType registry property not found: $_"
+    $null
+}
+if ($firmwareType -ne 2) {
+    Write-Host "[!!] This system does not report UEFI firmware (PEFirmwareType = $firmwareType)." -ForegroundColor Red
+    Write-Host "     pcHealth only repairs UEFI boot files. A legacy BIOS/MBR install" -ForegroundColor Yellow
+    Write-Host "     needs recovery media and manual repair." -ForegroundColor Yellow
+    Write-Host ''
+    return
+}
 
 $confirm1 = (Read-Host "  Type 'yes' to continue or anything else to cancel").Trim().ToLower()
 if ($confirm1 -ne 'yes') {
@@ -72,22 +94,26 @@ if ($win) {
 } else { Write-Warning "Skipping SFC — Windows partition not found." }
 Write-Host "[OK] SFC done.`n" -ForegroundColor Green
 
-Write-Host "[>>] Step 3/3 -- BOOTREC..." -ForegroundColor Yellow
-& bootrec.exe /fixmbr
-$fixboot = & bootrec.exe /fixboot 2>&1
-& bootrec.exe /scanos
-& bootrec.exe /rebuildbcd
-
-if ($fixboot -match 'Access is denied') {
-    Write-Warning "/fixboot access denied -- attempting bcdboot fallback (EFI)..."
+Write-Host "[>>] Step 3/3 -- Rewriting EFI boot files (bcdboot)..." -ForegroundColor Yellow
+if (-not $windir) {
+    Write-Warning "Windows partition not found -- cannot rebuild the boot files."
+} else {
+    # The EFI System Partition normally has no drive letter; mountvol /S assigns
+    # one so bcdboot can write to it.
     & mountvol.exe S: /S
     if (Test-Path 'S:\') {
-        & bcdboot.exe $windir /s S: /f ALL
-        Write-Host "[OK] bcdboot completed." -ForegroundColor Green
+        # /f UEFI, not /f ALL: ALL also writes BIOS boot files, which nothing in
+        # the supported range boots from.
+        & bcdboot.exe $windir /s S: /f UEFI
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "[OK] EFI boot files rewritten.`n" -ForegroundColor Green
+        } else {
+            Write-Warning "bcdboot exited with code $LASTEXITCODE."
+        }
+        & mountvol.exe S: /D
     } else {
-        Write-Warning "Could not mount EFI partition. Manual intervention may be required."
+        Write-Warning "Could not mount the EFI System Partition. Manual intervention may be required."
     }
 }
-Write-Host "[OK] BOOTREC done.`n" -ForegroundColor Green
 
 Write-Host "All steps completed. Reboot the system to verify.`n" -ForegroundColor Green

--- a/src/CLI/tools/Invoke-PowerOptions.ps1
+++ b/src/CLI/tools/Invoke-PowerOptions.ps1
@@ -17,12 +17,16 @@ $choice = (Read-Host "  Choice").Trim().ToUpper()
 if ($IsLinux) {
     switch ($choice) {
         '1' {
-            $ok = (Read-Host "`n  Log off $env:USER? (y/n)").Trim().ToLower()
+            # Under sudo $env:USER is root; log off the human behind it instead.
+            $desktopUser = (Get-PcDesktopUser)?.Name
+            if (-not $desktopUser) {
+                Write-Host "`n  [!!] Could not determine the desktop user.`n" -ForegroundColor Red
+                return
+            }
+            $ok = (Read-Host "`n  Log off $desktopUser? (y/n)").Trim().ToLower()
             if ($ok -eq 'y') {
-                # loginctl terminates the current user session cleanly.
-                # Quote the username so loginctl receives it as a single token even
-                # if $env:USER contains spaces (uncommon but possible).
-                & loginctl terminate-user "$env:USER"
+                # loginctl terminates the user's session cleanly.
+                & loginctl terminate-user $desktopUser
             } else { Write-Host "`n  Cancelled.`n" -ForegroundColor DarkGray }
         }
         '2' {

--- a/src/CLI/tools/Open-BIOSPasswordTool.ps1
+++ b/src/CLI/tools/Open-BIOSPasswordTool.ps1
@@ -24,8 +24,8 @@ while ($true) {
     $choice = (Read-Host "  Choice").Trim().ToUpper()
 
     switch ($choice) {
-        '1' { Start-Process 'https://bios-pw.org' }
-        '2' { Start-Process 'https://github.com/bacher09/pwgen-for-bios' }
+        '1' { Open-PcUrl 'https://bios-pw.org' }
+        '2' { Open-PcUrl 'https://github.com/bacher09/pwgen-for-bios' }
         'B' { return }
         default { Write-Host "`n  Invalid choice.`n" -ForegroundColor Red }
     }

--- a/src/CLI/tools/linux/Get-BatteryReport.ps1
+++ b/src/CLI/tools/linux/Get-BatteryReport.ps1
@@ -1,0 +1,87 @@
+﻿#Requires -Version 7.0
+# ============================================================================
+# pcHealth -- Battery Report (Linux)
+# Reads the kernel's power_supply class directly. No external tool needed:
+# upower and acpi both read the same sysfs files.
+# ============================================================================
+
+Write-Host "`n$('=' * 60)" -ForegroundColor Cyan
+Write-Host '  Battery Report' -ForegroundColor Cyan
+Write-Host "$('=' * 60)`n" -ForegroundColor Cyan
+
+# Attribute names vary by driver and any of them may be absent.
+function Get-SysAttribute {
+    param([string]$Dir, [string[]]$Names)
+    foreach ($name in $Names) {
+        $path = Join-Path $Dir $name
+        if (Test-Path $path) {
+            $value = try { (Get-Content $path -Raw -ErrorAction Stop).Trim() } catch { $null }
+            if ($value) { return $value }
+        }
+    }
+    return $null
+}
+
+$supplyRoot = '/sys/class/power_supply'
+if (-not (Test-Path $supplyRoot)) {
+    Write-Host "[!!] $supplyRoot not found -- this kernel exposes no power supplies.`n" -ForegroundColor Red
+    return
+}
+
+$batteries = @(Get-ChildItem $supplyRoot -ErrorAction SilentlyContinue |
+    Where-Object { (Get-SysAttribute $_.FullName @('type')) -eq 'Battery' })
+
+if (-not $batteries) {
+    Write-Host "[!] No battery detected -- this looks like a desktop system.`n" -ForegroundColor Yellow
+    return
+}
+
+foreach ($bat in $batteries) {
+    $dir = $bat.FullName
+
+    # Drivers report either energy (uWh) or charge (uAh); the health ratio holds
+    # for both as long as full and design come from the same pair.
+    $full       = Get-SysAttribute $dir @('energy_full', 'charge_full')
+    $design     = Get-SysAttribute $dir @('energy_full_design', 'charge_full_design')
+    $unit       = if (Test-Path (Join-Path $dir 'energy_full')) { 'Wh' } else { 'Ah' }
+    $healthPct  = if ($full -and $design -and [double]$design -gt 0) {
+        [Math]::Round(([double]$full / [double]$design) * 100, 1)
+    } else { $null }
+
+    $cycles  = Get-SysAttribute $dir @('cycle_count')
+    $now     = Get-SysAttribute $dir @('energy_now', 'charge_now')
+    $power   = Get-SysAttribute $dir @('power_now', 'current_now')
+    $voltage = Get-SysAttribute $dir @('voltage_now')
+
+    # sysfs reports micro-units throughout.
+    $toUnit = { param($raw) if ($raw) { [Math]::Round([double]$raw / 1e6, 2) } else { 'N/A' } }
+
+    [PSCustomObject]@{
+        'Battery'        = $bat.Name
+        'Manufacturer'   = (Get-SysAttribute $dir @('manufacturer'))  ?? 'N/A'
+        'Model'          = (Get-SysAttribute $dir @('model_name'))    ?? 'N/A'
+        'Technology'     = (Get-SysAttribute $dir @('technology'))    ?? 'N/A'
+        'Status'         = (Get-SysAttribute $dir @('status'))        ?? 'N/A'
+        'Charge'         = ((Get-SysAttribute $dir @('capacity'))     ?? 'N/A') + '%'
+        "Full ($unit)"   = & $toUnit $full
+        "Design ($unit)" = & $toUnit $design
+        "Now ($unit)"    = & $toUnit $now
+        'Voltage (V)'    = & $toUnit $voltage
+        'Draw'           = if ($power) { "$(& $toUnit $power) $(if ($unit -eq 'Wh') { 'W' } else { 'A' })" } else { 'N/A' }
+        'Cycle Count'    = $cycles ?? 'Not reported by driver'
+        'Health'         = if ($null -ne $healthPct) { "$healthPct%" } else { 'N/A' }
+    } | Format-List | Out-Host
+
+    if ($null -ne $healthPct) {
+        $verdict, $colour = switch ($healthPct) {
+            { $_ -ge 80 } { 'Good -- the battery holds most of its design capacity.', 'Green';  break }
+            { $_ -ge 60 } { 'Worn -- noticeably reduced runtime.',                    'Yellow'; break }
+            default       { 'Poor -- consider replacing the battery.',                'Red' }
+        }
+        Write-Host "  $verdict" -ForegroundColor $colour
+    }
+    if (-not $cycles) {
+        Write-Host '  [*] Many laptop batteries do not expose a cycle count to the kernel.' -ForegroundColor DarkGray
+    }
+    Write-Host ''
+}

--- a/src/CLI/tools/linux/Get-SystemLogs.ps1
+++ b/src/CLI/tools/linux/Get-SystemLogs.ps1
@@ -17,6 +17,7 @@ Write-Host "  [1]  Errors from today"
 Write-Host "  [2]  Last 100 error/warning entries"
 Write-Host "  [3]  Boot messages (current boot)"
 Write-Host "  [4]  Kernel messages (dmesg)"
+Write-Host "  [5]  Failed services"
 Write-Host "  [B]  Back`n"
 
 $choice = (Read-Host "  Choice").Trim().ToUpper()
@@ -37,6 +38,16 @@ switch ($choice) {
     '4' {
         Write-Host "`n[>>] Kernel messages...`n" -ForegroundColor Yellow
         & dmesg --level=err,warn 2>$null | tail -n 50
+    }
+    '5' {
+        Write-Host "`n[>>] Failed systemd units...`n" -ForegroundColor Yellow
+        $failed = Get-PcCommandOutput 'systemctl' @('--failed', '--no-legend', '--no-pager')
+        if ($failed) {
+            Write-Host $failed
+            Write-Host "`n  Inspect one with: journalctl -u <unit> -b" -ForegroundColor DarkGray
+        } else {
+            Write-Host '  No failed units.' -ForegroundColor Green
+        }
     }
     'B' { return }
     default { Write-Host "`n  Invalid choice.`n" -ForegroundColor Red }

--- a/src/CLI/tools/linux/Invoke-AudioRestart.ps1
+++ b/src/CLI/tools/linux/Invoke-AudioRestart.ps1
@@ -2,37 +2,30 @@
 # ============================================================================
 # pcHealth -- Restart Audio (Linux)
 # Detects PipeWire or PulseAudio and restarts the relevant user services.
-# systemctl --user requires DBUS_SESSION_BUS_ADDRESS forwarded to work
-# when pcHealth is invoked via sudo.
+# The audio server lives in the user's session, not root's, so every call is
+# dropped to the desktop user with their session bus forwarded.
 # ============================================================================
 
 Write-Host "`n$('=' * 60)" -ForegroundColor Cyan
 Write-Host '  Restart Audio' -ForegroundColor Cyan
 Write-Host "$('=' * 60)`n" -ForegroundColor Cyan
 
-$user   = $env:SUDO_USER ?? $env:USER
-$userId = (& id -u "$user" 2>$null).Trim()
-$dbus   = $env:DBUS_SESSION_BUS_ADDRESS ?? "unix:path=/run/user/$userId/bus"
-
-# Valid DBUS transport prefixes per the D-Bus specification.
-$ValidDbusPattern = '^(unix|tcp|nonce-tcp|autolaunch):'
-
-# Validate the DBUS address has the expected format before embedding it in an
-# env key=value argument. A well-formed address starts with a known transport prefix.
-if ($dbus -notmatch $ValidDbusPattern) {
-    Write-Host "[!!] Unexpected DBUS_SESSION_BUS_ADDRESS format: $dbus" -ForegroundColor Red
-    Write-Host "     Aborting to avoid passing an untrusted value to env." -ForegroundColor Red
+$user = Get-PcDesktopUser
+if (-not $user) {
+    Write-Host "[!!] Could not determine the desktop user.`n" -ForegroundColor Red
     return
 }
 
-# Invoke a systemctl --user command as the target user, forwarding DBUS via the
-# environment rather than injecting it into a shell command string.
-# systemctl and its arguments are passed as individual tokens — no shell involved.
-function Invoke-UserServiceUnit {
-    param([string]$Label, [string]$Action, [string]$Unit)
-    Write-Host "[>>] $Label" -ForegroundColor Yellow
-    $out = & sudo -u "$user" env "DBUS_SESSION_BUS_ADDRESS=$dbus" `
-        systemctl --user $Action $Unit 2>&1
+# systemctl and its arguments are passed as individual tokens -- no shell involved.
+function Invoke-UserCommand {
+    param([string[]]$CommandLine)
+    return & sudo -u $user.Name env "DBUS_SESSION_BUS_ADDRESS=$($user.Dbus)" @CommandLine 2>&1
+}
+
+function Restart-UserUnit {
+    param([string]$Unit)
+    Write-Host "[>>] Restarting $Unit..." -ForegroundColor Yellow
+    $out = Invoke-UserCommand @('systemctl', '--user', 'restart', $Unit)
     if ($LASTEXITCODE -eq 0) {
         Write-Host "[OK] Done.`n" -ForegroundColor Green
     } else {
@@ -41,22 +34,21 @@ function Invoke-UserServiceUnit {
     }
 }
 
-$isPipeWire = (& sudo -u "$user" env "DBUS_SESSION_BUS_ADDRESS=$dbus" `
-    systemctl --user is-active pipewire 2>/dev/null).Trim() -eq 'active'
+# Exact match: `is-active` answers "inactive" too, which -match 'active' would accept.
+$pipeWireState = "$(Invoke-UserCommand @('systemctl', '--user', 'is-active', 'pipewire'))".Trim()
+$isPipeWire = $pipeWireState -eq 'active'
 $hasPulse   = [bool](Get-Command pulseaudio -ErrorAction SilentlyContinue)
 
 if ($isPipeWire) {
     Write-Host "  Detected: PipeWire`n" -ForegroundColor DarkGray
-    Invoke-UserServiceUnit -Label 'Restarting pipewire...'       -Action restart -Unit pipewire
-    Invoke-UserServiceUnit -Label 'Restarting pipewire-pulse...' -Action restart -Unit pipewire-pulse
-    Invoke-UserServiceUnit -Label 'Restarting wireplumber...'    -Action restart -Unit wireplumber
+    'pipewire', 'pipewire-pulse', 'wireplumber' | ForEach-Object { Restart-UserUnit $_ }
 } elseif ($hasPulse) {
     Write-Host "  Detected: PulseAudio`n" -ForegroundColor DarkGray
-    # Kill then start as two separate invocations to avoid a shell compound command.
-    Write-Host "[>>] Restarting PulseAudio..." -ForegroundColor Yellow
-    & sudo -u "$user" env "DBUS_SESSION_BUS_ADDRESS=$dbus" pulseaudio --kill 2>&1 | Out-Null
+    Write-Host '[>>] Restarting PulseAudio...' -ForegroundColor Yellow
+    # Kill then start as two invocations to avoid a shell compound command.
+    Invoke-UserCommand @('pulseaudio', '--kill') | Out-Null
     Start-Sleep -Milliseconds 500
-    $out = & sudo -u "$user" env "DBUS_SESSION_BUS_ADDRESS=$dbus" pulseaudio --start 2>&1
+    $out = Invoke-UserCommand @('pulseaudio', '--start')
     if ($LASTEXITCODE -eq 0) {
         Write-Host "[OK] Done.`n" -ForegroundColor Green
     } else {

--- a/src/CLI/tools/linux/Invoke-BootRepair.ps1
+++ b/src/CLI/tools/linux/Invoke-BootRepair.ps1
@@ -23,6 +23,20 @@ Write-Host '  WARNING: This operation modifies boot-critical files.' -Foreground
 Write-Host '  Incorrect use can render the system unbootable.' -ForegroundColor Yellow
 Write-Host "  Only proceed if you understand what you are doing.`n" -ForegroundColor Yellow
 
+# -- Image-based guard ---------------------------------------------------------
+# On ostree systems the bootloader entries are generated from the deployments
+# (/boot/loader/entries). Reinstalling GRUB or systemd-boot by hand here fights
+# whatever produced those entries; `bootc`/`rpm-ostree` own this, not pcHealth.
+if (Test-PcImageBasedSystem) {
+    Write-Host '[!!] This is an image-based system (ostree).' -ForegroundColor Red
+    Write-Host '     Its bootloader is managed by the deployment, not by hand.' -ForegroundColor Yellow
+    Write-Host '     Roll back to a working deployment instead:' -ForegroundColor Yellow
+    Write-Host '       rpm-ostree status      # list deployments' -ForegroundColor DarkGray
+    Write-Host '       rpm-ostree rollback    # boot the previous one' -ForegroundColor DarkGray
+    Write-Host ''
+    return
+}
+
 # -- Firmware guard ------------------------------------------------------------
 if (-not (Test-Path '/sys/firmware/efi')) {
     Write-Host '[!!] This system booted in legacy BIOS mode (no /sys/firmware/efi).' -ForegroundColor Red

--- a/src/CLI/tools/linux/Invoke-BootRepair.ps1
+++ b/src/CLI/tools/linux/Invoke-BootRepair.ps1
@@ -1,0 +1,195 @@
+﻿#Requires -Version 7.0
+# ============================================================================
+# pcHealth -- Boot Repair (Linux, UEFI)
+# Reinstalls the bootloader's EFI files. Supports systemd-boot, GRUB and Limine.
+#
+# UEFI only, deliberately. pcHealth's minimum is kernel 7.0, and repairing a
+# legacy BIOS/MBR setup means writing raw boot code to the disk -- a different
+# and far riskier operation than reinstalling an EFI binary onto the ESP.
+#
+# Every repair below runs the bootloader's own official command. pcHealth never
+# writes boot sectors itself and never guesses which loader you use.
+# ============================================================================
+
+if (Get-Command Set-PcTheme -ErrorAction SilentlyContinue) {
+    Set-PcTheme 'Danger'
+    Clear-PcHost
+}
+
+Write-Host "`n$('=' * 60)" -ForegroundColor Red
+Write-Host '  Boot Repair  (UEFI)' -ForegroundColor Red
+Write-Host "$('=' * 60)`n" -ForegroundColor Red
+Write-Host '  WARNING: This operation modifies boot-critical files.' -ForegroundColor Yellow
+Write-Host '  Incorrect use can render the system unbootable.' -ForegroundColor Yellow
+Write-Host "  Only proceed if you understand what you are doing.`n" -ForegroundColor Yellow
+
+# -- Firmware guard ------------------------------------------------------------
+if (-not (Test-Path '/sys/firmware/efi')) {
+    Write-Host '[!!] This system booted in legacy BIOS mode (no /sys/firmware/efi).' -ForegroundColor Red
+    Write-Host '     pcHealth only repairs UEFI bootloaders.' -ForegroundColor Yellow
+    Write-Host ''
+    return
+}
+
+# EFI binary name and GRUB target follow the firmware's bitness, not the CPU's:
+# a 64-bit CPU can ship 32-bit UEFI firmware, and BOOTX64 will not boot there.
+$machine  = (Get-PcCommandOutput 'uname' @('-m')) ?? 'x86_64'
+$fwBits   = try { (Get-Content '/sys/firmware/efi/fw_platform_size' -Raw -ErrorAction Stop).Trim() } catch { '64' }
+$efiName, $grubTarget = switch -Regex ($machine) {
+    '^aarch64|^arm64' { 'BOOTAA64.EFI', 'arm64-efi'; break }
+    default           { if ($fwBits -eq '32') { 'BOOTIA32.EFI', 'i386-efi' } else { 'BOOTX64.EFI', 'x86_64-efi' } }
+}
+
+# -- Locate the EFI System Partition -------------------------------------------
+# Only trust a mounted vfat partition. Mounting one ourselves would mean picking
+# a candidate by guesswork, on the one filesystem where a wrong guess is fatal.
+$esp = $null
+foreach ($candidate in @('/efi', '/boot/efi', '/boot')) {
+    $fsType = Get-PcCommandOutput 'findmnt' @('-rno', 'FSTYPE', '--target', $candidate)
+    if ($fsType -eq 'vfat') { $esp = $candidate; break }
+}
+
+if (-not $esp) {
+    Write-Host '[!!] No mounted EFI System Partition found at /efi, /boot/efi or /boot.' -ForegroundColor Red
+    Write-Host '     Mount it first, then run this tool again. Candidates:' -ForegroundColor Yellow
+    & lsblk -o NAME,SIZE,FSTYPE,PARTTYPENAME,MOUNTPOINT 2>$null |
+        Where-Object { $_ -match 'EFI System|vfat|NAME' } |
+        ForEach-Object { Write-Host "  $_" -ForegroundColor DarkGray }
+    Write-Host ''
+    return
+}
+
+Write-Host "  Firmware:     UEFI ($fwBits-bit, $machine)" -ForegroundColor DarkGray
+Write-Host "  ESP:          $esp" -ForegroundColor DarkGray
+Write-Host "  EFI binary:   $efiName`n" -ForegroundColor DarkGray
+
+# -- Detect which bootloaders are installed ------------------------------------
+$loaders = @()
+
+if ((Test-Path (Join-Path $esp 'EFI/systemd')) -or (Get-Command bootctl -ErrorAction SilentlyContinue)) {
+    $installed = Test-Path (Join-Path $esp 'EFI/systemd')
+    $loaders += [PSCustomObject]@{
+        Name     = 'systemd-boot'
+        Present  = $installed
+        Commands = [string[][]]@(, @('bootctl', 'install', "--esp-path=$esp"))
+    }
+}
+
+$grubCmd = @('grub-install', 'grub2-install') |
+    Where-Object { Get-Command $_ -CommandType Application -ErrorAction SilentlyContinue } |
+    Select-Object -First 1
+if ($grubCmd) {
+    # Fedora/RHEL name everything grub2-* and keep the config under /boot/grub2.
+    $mkconfig = if ($grubCmd -eq 'grub2-install') { 'grub2-mkconfig' } else { 'grub-mkconfig' }
+    $grubDir  = if ($grubCmd -eq 'grub2-install') { '/boot/grub2' } else { '/boot/grub' }
+    $distroId = (Get-LinuxDistroInfo)['ID']
+    $bootId   = if ($distroId) { $distroId } else { 'linux' }
+    $loaders += [PSCustomObject]@{
+        Name     = 'GRUB'
+        Present  = (Test-Path $grubDir) -or (Test-Path (Join-Path $esp 'EFI/grub'))
+        # Commas matter: newline-separated elements collapse into one flat list,
+        # which would make $cmd[0] a single character instead of the command.
+        Commands = [string[][]]@(
+            @($grubCmd, "--target=$grubTarget", "--efi-directory=$esp", "--bootloader-id=$bootId"),
+            @($mkconfig, '-o', (Join-Path $grubDir 'grub.cfg'))
+        )
+    }
+}
+
+# Limine has no upstream UEFI installer -- the documented procedure is to copy
+# the EFI binary onto the ESP. Distros ship their own helper, so prefer that.
+$limineHelper = @('limine-update', 'limine-install') |
+    Where-Object { Get-Command $_ -CommandType Application -ErrorAction SilentlyContinue } |
+    Select-Object -First 1
+$limineSource = Join-Path '/usr/share/limine' $efiName
+if ($limineHelper -or (Test-Path $limineSource)) {
+    $limineCommands = if ($limineHelper) {
+        [string[][]]@(, @($limineHelper))
+    } else {
+        # Never `limine bios-install` here: that writes an MBR stage and is
+        # documented as BIOS-only.
+        [string[][]]@(
+            @('mkdir', '-p', (Join-Path $esp 'EFI/BOOT')),
+            @('cp', $limineSource, (Join-Path $esp "EFI/BOOT/$efiName"))
+        )
+    }
+    $loaders += [PSCustomObject]@{
+        Name     = 'Limine'
+        Present  = (Test-Path (Join-Path $esp "EFI/BOOT/$efiName")) -or
+                   (@('limine.conf', 'limine/limine.conf', 'boot/limine/limine.conf') |
+                        Where-Object { Test-Path (Join-Path $esp $_) }).Count -gt 0
+        Commands = $limineCommands
+    }
+}
+
+if (-not $loaders) {
+    Write-Host '[!!] No supported bootloader found (systemd-boot, GRUB or Limine).' -ForegroundColor Red
+    Write-Host '     Install your bootloader''s package first, then run this tool again.' -ForegroundColor Yellow
+    Write-Host ''
+    return
+}
+
+# -- Choose -------------------------------------------------------------------
+Write-Host '  Detected bootloaders:' -ForegroundColor Cyan
+for ($i = 0; $i -lt $loaders.Count; $i++) {
+    $state = if ($loaders[$i].Present) { 'installed on this ESP' } else { 'tooling present, not installed here' }
+    Write-PcOption "$($i + 1)" $loaders[$i].Name "($state)"
+}
+Write-PcOption 'B' 'Cancel'
+Write-Host ''
+
+$choice = (Read-Host '  Which bootloader should be repaired?').Trim()
+if ($choice -eq 'B' -or $choice -eq 'b') {
+    Write-Host "`n  Cancelled.`n" -ForegroundColor DarkGray
+    return
+}
+$index = 0
+if (-not [int]::TryParse($choice, [ref]$index) -or $index -lt 1 -or $index -gt $loaders.Count) {
+    Write-Host "`n  Invalid choice.`n" -ForegroundColor Red
+    return
+}
+$loader = $loaders[$index - 1]
+
+# -- Confirm, showing exactly what will run ------------------------------------
+Write-Host "`n  These commands will run as root:`n" -ForegroundColor Yellow
+foreach ($cmd in $loader.Commands) { Write-Host "    $($cmd -join ' ')" -ForegroundColor White }
+Write-Host ''
+
+$confirm1 = (Read-Host "  Type 'yes' to continue or anything else to cancel").Trim().ToLower()
+if ($confirm1 -ne 'yes') {
+    Write-Host "`n  Cancelled.`n" -ForegroundColor DarkGray
+    return
+}
+$confirm2 = (Read-Host "  Last chance -- type 'CONFIRM' in capitals to proceed").Trim()
+if ($confirm2 -ne 'CONFIRM') {
+    Write-Host "`n  Cancelled.`n" -ForegroundColor DarkGray
+    return
+}
+
+# -- Repair --------------------------------------------------------------------
+Write-Host ''
+foreach ($cmd in $loader.Commands) {
+    Write-Host "[>>] $($cmd -join ' ')" -ForegroundColor Yellow
+    & $cmd[0] @($cmd[1..($cmd.Count - 1)]) 2>&1 |
+        ForEach-Object { Write-Host "  $_" -ForegroundColor DarkGray }
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "`n[!!] Failed with exit code $LASTEXITCODE -- stopping here." -ForegroundColor Red
+        Write-Host '     The system may still boot from its existing entry. Do not reboot' -ForegroundColor Yellow
+        Write-Host '     until you have resolved this, and keep a live USB to hand.' -ForegroundColor Yellow
+        Write-Host ''
+        return
+    }
+}
+
+Write-Host "[OK] $($loader.Name) reinstalled on $esp.`n" -ForegroundColor Green
+
+# efibootmgr lets the user confirm the firmware entry exists before rebooting --
+# a copied EFI binary with no boot entry still leaves an unbootable machine.
+if (Get-Command efibootmgr -ErrorAction SilentlyContinue) {
+    Write-Host '  Current firmware boot entries:' -ForegroundColor Cyan
+    & efibootmgr 2>$null | ForEach-Object { Write-Host "  $_" -ForegroundColor DarkGray }
+    Write-Host ''
+}
+
+Write-Host '  Verify the entry above before rebooting.' -ForegroundColor Yellow
+Write-Host ''

--- a/src/CLI/tools/linux/Invoke-DiskCleanup.ps1
+++ b/src/CLI/tools/linux/Invoke-DiskCleanup.ps1
@@ -32,8 +32,17 @@ function Invoke-Cleanup {
 # ── Package cache ─────────────────────────────────────────────────────────────
 
 $archIds = @('arch', 'cachyos', 'garuda', 'manjaro', 'endeavouros', 'artix')
+$pm      = Get-PcPackageManager
 
-if ($distroId -in $archIds -or $distroLike -match 'arch') {
+if ($pm -and $pm.Atomic -and -not $pm.Clean) {
+    Write-Host "[--] $($pm.Cmd) manages the image as a whole and has no cache to clear.`n" -ForegroundColor DarkGray
+} elseif ($pm -and $pm.Atomic) {
+    # dnf autoremove/clean cannot touch a read-only /usr. The image-based
+    # equivalent frees cached metadata and temp files, leaving deployments alone.
+    Invoke-Cleanup 'Clearing rpm-ostree cache and temp files...' { & $pm.Cmd @($pm.Clean) }
+    Write-Host '[--] Deployments left untouched -- remove them deliberately with' -ForegroundColor DarkGray
+    Write-Host "     rpm-ostree cleanup -r (rollback) or -p (pending).`n" -ForegroundColor DarkGray
+} elseif ($distroId -in $archIds -or $distroLike -match 'arch') {
     if (Get-Command paccache -ErrorAction SilentlyContinue) {
         Invoke-Cleanup 'Clearing pacman cache (keeping last 2 versions)...' { paccache -rk2 }
     }

--- a/src/CLI/tools/linux/Invoke-DiskCleanup.ps1
+++ b/src/CLI/tools/linux/Invoke-DiskCleanup.ps1
@@ -35,24 +35,24 @@ $archIds = @('arch', 'cachyos', 'garuda', 'manjaro', 'endeavouros', 'artix')
 
 if ($distroId -in $archIds -or $distroLike -match 'arch') {
     if (Get-Command paccache -ErrorAction SilentlyContinue) {
-        Invoke-Cleanup 'Clearing pacman cache (keeping last 2 versions)...' { sudo paccache -rk2 }
+        Invoke-Cleanup 'Clearing pacman cache (keeping last 2 versions)...' { paccache -rk2 }
     }
     # Only remove orphans when there is actually something to remove;
     # passing an empty list to pacman -Rns causes a non-zero exit and confuses users.
     $orphans = @(& pacman -Qdtq 2>$null)
     if ($orphans.Count -gt 0) {
-        Invoke-Cleanup 'Removing unneeded pacman dependencies...' { sudo pacman -Rns $orphans --noconfirm }
+        Invoke-Cleanup 'Removing unneeded pacman dependencies...' { pacman -Rns $orphans --noconfirm }
     } else {
         Write-Host "[--] No unneeded pacman dependencies found, skipping.`n" -ForegroundColor DarkGray
     }
 } elseif ($distroId -in @('ubuntu', 'debian', 'linuxmint', 'pop', 'elementary', 'zorin', 'kali') -or $distroLike -match 'debian|ubuntu') {
-    Invoke-Cleanup 'Removing unneeded apt packages...' { sudo apt autoremove -y }
-    Invoke-Cleanup 'Cleaning apt cache...'             { sudo apt autoclean }
+    Invoke-Cleanup 'Removing unneeded apt packages...' { apt autoremove -y }
+    Invoke-Cleanup 'Cleaning apt cache...'             { apt autoclean }
 } elseif ($distroId -in @('fedora', 'rhel', 'centos', 'almalinux', 'rocky') -or $distroLike -match 'fedora|rhel') {
-    Invoke-Cleanup 'Removing unneeded dnf packages...' { sudo dnf autoremove -y }
-    Invoke-Cleanup 'Cleaning dnf cache...'             { sudo dnf clean all }
+    Invoke-Cleanup 'Removing unneeded dnf packages...' { dnf autoremove -y }
+    Invoke-Cleanup 'Cleaning dnf cache...'             { dnf clean all }
 } elseif ($distroId -in @('opensuse-leap', 'opensuse-tumbleweed', 'sles') -or $distroLike -match 'suse') {
-    Invoke-Cleanup 'Cleaning zypper cache...' { sudo zypper clean --all }
+    Invoke-Cleanup 'Cleaning zypper cache...' { zypper clean --all }
 } else {
     Write-Host "[--] Package cache: distro not recognised, skipping.`n" -ForegroundColor DarkGray
 }
@@ -61,19 +61,19 @@ if ($distroId -in $archIds -or $distroLike -match 'arch') {
 
 if (Get-Command journalctl -ErrorAction SilentlyContinue) {
     Invoke-Cleanup 'Vacuuming journal logs (keeping last 7 days)...' {
-        sudo journalctl --vacuum-time=7d
+        journalctl --vacuum-time=7d
     }
 }
 
 # ── Flatpak unused runtimes ───────────────────────────────────────────────────
 
 if (Get-Command flatpak -ErrorAction SilentlyContinue) {
-    Invoke-Cleanup 'Removing unused Flatpak runtimes...' { sudo flatpak uninstall --unused -y }
+    Invoke-Cleanup 'Removing unused Flatpak runtimes...' { flatpak uninstall --unused -y }
 }
 
 # ── Thumbnail cache ───────────────────────────────────────────────────────────
 
-# Under sudo $env:HOME is root's, so resolve the desktop user's cache instead.
+# Under $env:HOME is root's, so resolve the desktop user's cache instead.
 $userHome = (Get-PcDesktopUser)?.Home
 $thumbDir = if ($userHome) { Join-Path $userHome '.cache/thumbnails' } else { $null }
 if ($thumbDir -and (Test-Path $thumbDir)) {

--- a/src/CLI/tools/linux/Invoke-DiskCleanup.ps1
+++ b/src/CLI/tools/linux/Invoke-DiskCleanup.ps1
@@ -18,6 +18,9 @@ Write-Host "  Distro: $($osRelease['PRETTY_NAME'])`n" -ForegroundColor DarkGray
 function Invoke-Cleanup {
     param([string]$Label, [scriptblock]$Action)
     Write-Host "[>>] $Label" -ForegroundColor Yellow
+    # Reset first: a step that runs no native command would otherwise be judged
+    # by whichever exit code was left behind by the previous one.
+    $global:LASTEXITCODE = 0
     & $Action 2>&1 | ForEach-Object { Write-Host "  $_" -ForegroundColor DarkGray }
     if ($LASTEXITCODE -eq 0) {
         Write-Host "[OK] Done.`n" -ForegroundColor Green
@@ -70,13 +73,15 @@ if (Get-Command flatpak -ErrorAction SilentlyContinue) {
 
 # ── Thumbnail cache ───────────────────────────────────────────────────────────
 
-$thumbDir = Join-Path $env:HOME '.cache/thumbnails'
-if (Test-Path $thumbDir) {
+# Under sudo $env:HOME is root's, so resolve the desktop user's cache instead.
+$userHome = (Get-PcDesktopUser)?.Home
+$thumbDir = if ($userHome) { Join-Path $userHome '.cache/thumbnails' } else { $null }
+if ($thumbDir -and (Test-Path $thumbDir)) {
     $sizeMB = [math]::Round(
         (Get-ChildItem $thumbDir -Recurse -File -ErrorAction SilentlyContinue |
             Measure-Object -Property Length -Sum).Sum / 1MB, 1)
     Invoke-Cleanup "Clearing thumbnail cache ($sizeMB MB)..." {
-        Get-ChildItem (Join-Path $env:HOME '.cache/thumbnails') -Recurse -File -ErrorAction SilentlyContinue |
+        Get-ChildItem $thumbDir -Recurse -File -ErrorAction SilentlyContinue |
             Remove-Item -Force -ErrorAction SilentlyContinue
     }
 }

--- a/src/CLI/tools/linux/Invoke-DiskCleanup.ps1
+++ b/src/CLI/tools/linux/Invoke-DiskCleanup.ps1
@@ -32,17 +32,8 @@ function Invoke-Cleanup {
 # ── Package cache ─────────────────────────────────────────────────────────────
 
 $archIds = @('arch', 'cachyos', 'garuda', 'manjaro', 'endeavouros', 'artix')
-$pm      = Get-PcPackageManager
 
-if ($pm -and $pm.Atomic -and -not $pm.Clean) {
-    Write-Host "[--] $($pm.Cmd) manages the image as a whole and has no cache to clear.`n" -ForegroundColor DarkGray
-} elseif ($pm -and $pm.Atomic) {
-    # dnf autoremove/clean cannot touch a read-only /usr. The image-based
-    # equivalent frees cached metadata and temp files, leaving deployments alone.
-    Invoke-Cleanup 'Clearing rpm-ostree cache and temp files...' { & $pm.Cmd @($pm.Clean) }
-    Write-Host '[--] Deployments left untouched -- remove them deliberately with' -ForegroundColor DarkGray
-    Write-Host "     rpm-ostree cleanup -r (rollback) or -p (pending).`n" -ForegroundColor DarkGray
-} elseif ($distroId -in $archIds -or $distroLike -match 'arch') {
+if ($distroId -in $archIds -or $distroLike -match 'arch') {
     if (Get-Command paccache -ErrorAction SilentlyContinue) {
         Invoke-Cleanup 'Clearing pacman cache (keeping last 2 versions)...' { paccache -rk2 }
     }

--- a/src/CLI/tools/linux/Invoke-DiskOptimize.ps1
+++ b/src/CLI/tools/linux/Invoke-DiskOptimize.ps1
@@ -1,0 +1,56 @@
+﻿#Requires -Version 7.0
+# ============================================================================
+# pcHealth -- Disk Optimization (Linux)
+# Counterpart to dfrgui.exe on Windows. Linux filesystems do not need
+# defragmenting, so the useful half of that job is discarding unused blocks
+# on SSDs, which is what fstrim does.
+# ============================================================================
+
+Write-Host "`n$('=' * 60)" -ForegroundColor Cyan
+Write-Host '  Disk Optimization' -ForegroundColor Cyan
+Write-Host "$('=' * 60)`n" -ForegroundColor Cyan
+
+# rotational = 1 means spinning rust: nothing to trim, and ext4/btrfs/xfs do not
+# fragment the way NTFS does, so there is nothing to defragment either.
+$disks = @(Get-ChildItem '/sys/block' -ErrorAction SilentlyContinue |
+    Where-Object { $_.Name -notmatch '^(loop|ram|zram|sr)' } |
+    ForEach-Object {
+        $rotational = try { (Get-Content (Join-Path $_.FullName 'queue/rotational') -Raw -ErrorAction Stop).Trim() } catch { $null }
+        [PSCustomObject]@{
+            Disk = $_.Name
+            Type = switch ($rotational) { '0' { 'SSD / NVMe' } '1' { 'HDD' } default { 'Unknown' } }
+        }
+    })
+
+if ($disks) {
+    $disks | Format-Table -AutoSize | Out-Host
+    if ($disks.Type -notcontains 'SSD / NVMe') {
+        Write-Host "  No solid-state device detected -- there is nothing to trim." -ForegroundColor Yellow
+        Write-Host "  Linux filesystems do not need defragmenting.`n" -ForegroundColor DarkGray
+        return
+    }
+}
+
+if (-not (Get-Command fstrim -ErrorAction SilentlyContinue)) {
+    Write-Host "[!!] fstrim not found. Install util-linux.`n" -ForegroundColor Red
+    return
+}
+
+# Many distros already run fstrim.timer weekly; say so rather than implying
+# the manual run was necessary.
+$timer = Get-PcCommandOutput 'systemctl' @('is-enabled', 'fstrim.timer')
+if ($timer -eq 'enabled') {
+    Write-Host "  Note: fstrim.timer is enabled, so this already runs weekly.`n" -ForegroundColor DarkGray
+}
+
+Write-Host "[>>] Trimming all mounted filesystems that support it..." -ForegroundColor Yellow
+Write-Host "     This can take a minute on a large or nearly full disk.`n" -ForegroundColor DarkGray
+
+# --all walks every mounted filesystem; --verbose reports bytes freed per mount.
+& fstrim --all --verbose 2>&1 | ForEach-Object { Write-Host "  $_" -ForegroundColor DarkGray }
+
+if ($LASTEXITCODE -eq 0) {
+    Write-Host "`n[OK] Trim complete.`n" -ForegroundColor Green
+} else {
+    Write-Host "`n[!!] fstrim exited with code $LASTEXITCODE.`n" -ForegroundColor Red
+}

--- a/src/CLI/tools/linux/Invoke-FirmwareUpdate.ps1
+++ b/src/CLI/tools/linux/Invoke-FirmwareUpdate.ps1
@@ -1,0 +1,78 @@
+﻿#Requires -Version 7.0
+# ============================================================================
+# pcHealth -- Firmware Update (Linux)
+# Counterpart to HP Image Assistant on Windows, but vendor-neutral: fwupd
+# ships BIOS, dock, SSD and peripheral firmware from LVFS for most vendors.
+# ============================================================================
+
+Write-Host "`n$('=' * 60)" -ForegroundColor Cyan
+Write-Host '  Firmware Update  (fwupd / LVFS)' -ForegroundColor Cyan
+Write-Host "$('=' * 60)`n" -ForegroundColor Cyan
+
+if (-not (Get-Command fwupdmgr -ErrorAction SilentlyContinue)) {
+    Write-Host '[!!] fwupdmgr is not installed.' -ForegroundColor Red
+    Write-Host ''
+    Write-Host '  Install it with your package manager:' -ForegroundColor DarkGray
+    Write-Host '    Debian / Ubuntu:  apt install fwupd'    -ForegroundColor DarkGray
+    Write-Host '    Fedora / RHEL:    dnf install fwupd'    -ForegroundColor DarkGray
+    Write-Host '    Arch / CachyOS:   pacman -S fwupd'      -ForegroundColor DarkGray
+    Write-Host '    openSUSE:         zypper install fwupd' -ForegroundColor DarkGray
+    Write-Host ''
+    return
+}
+
+Write-Host '[>>] Refreshing firmware metadata from LVFS...' -ForegroundColor Yellow
+# --force refreshes even when the cached metadata is still considered fresh.
+$refresh = & fwupdmgr refresh --force 2>&1 | ForEach-Object { "$_" }
+$refresh | ForEach-Object { Write-Host "  $_" -ForegroundColor DarkGray }
+# Without fresh metadata the verdict below reflects whatever was cached, which
+# may be months old -- say so rather than reporting a confident "up to date".
+$staleMetadata = [bool]($refresh -match 'Failed to download|transient failure|Failed to connect')
+
+Write-Host "`n[>>] Checking for firmware updates...`n" -ForegroundColor Yellow
+$updates = & fwupdmgr get-updates 2>&1 | ForEach-Object { "$_" }
+
+# fwupd is a daemon; the CLI still exits having printed nothing useful when it
+# is masked or not running. Never fall through to the install prompt on that --
+# an empty update list must not become an invitation to flash firmware.
+if ($updates -match 'Failed to connect to daemon|Failed to load daemon|could not be activated') {
+    Write-Host '[!!] Could not reach the fwupd daemon.' -ForegroundColor Red
+    Write-Host '     Start it with: systemctl start fwupd' -ForegroundColor DarkGray
+    Write-Host ''
+    return
+}
+
+# fwupdmgr exits non-zero when there is simply nothing to do, so read the text.
+if (-not $updates -or
+    $updates -match 'No updatable devices|No updates available|Devices with no available firmware updates') {
+    if ($staleMetadata) {
+        Write-Host '[!] No updates found, but the LVFS metadata could not be refreshed.' -ForegroundColor Yellow
+        Write-Host "    This answer is based on cached data -- check again once you are online.`n" -ForegroundColor DarkGray
+    } else {
+        Write-Host "[OK] All firmware is up to date.`n" -ForegroundColor Green
+    }
+    return
+}
+
+$updates | ForEach-Object { Write-Host "  $_" -ForegroundColor DarkGray }
+
+Write-Host ''
+Write-Host '  [!] Firmware updates carry real risk. Do not power the machine off' -ForegroundColor Yellow
+Write-Host '      while one is running, and plug in the charger on a laptop.'      -ForegroundColor Yellow
+Write-Host ''
+
+$confirm = (Read-Host '  Install these firmware updates? (y/n)').Trim().ToLower()
+if ($confirm -ne 'y') {
+    Write-Host "`n  Cancelled.`n" -ForegroundColor DarkGray
+    return
+}
+
+Write-Host "`n[>>] Installing firmware updates...`n" -ForegroundColor Yellow
+& fwupdmgr update
+
+if ($LASTEXITCODE -eq 0) {
+    Write-Host "`n[OK] Firmware update complete." -ForegroundColor Green
+    Write-Host "     Some devices only apply the update on the next reboot.`n" -ForegroundColor DarkGray
+} else {
+    Write-Host "`n[!!] fwupdmgr exited with code $LASTEXITCODE.`n" -ForegroundColor Red
+}

--- a/src/CLI/tools/linux/Invoke-NetworkReset.ps1
+++ b/src/CLI/tools/linux/Invoke-NetworkReset.ps1
@@ -31,15 +31,15 @@ Write-Host "  Note: the network connection will drop briefly.`n" -ForegroundColo
 $nmActive = (Get-PcCommandOutput 'systemctl' @('is-active', 'NetworkManager')) -eq 'active'
 
 if ($nmActive -or (Get-Command nmcli -ErrorAction SilentlyContinue)) {
-    Invoke-Step 'Restarting NetworkManager...' { sudo systemctl restart NetworkManager }
+    Invoke-Step 'Restarting NetworkManager...' { systemctl restart NetworkManager }
 } else {
-    Invoke-Step 'Restarting systemd-networkd...' { sudo systemctl restart systemd-networkd }
+    Invoke-Step 'Restarting systemd-networkd...' { systemctl restart systemd-networkd }
 }
 
 if (Get-Command resolvectl -ErrorAction SilentlyContinue) {
-    Invoke-Step 'Flushing DNS cache...' { sudo resolvectl flush-caches }
+    Invoke-Step 'Flushing DNS cache...' { resolvectl flush-caches }
 } elseif (Get-Command systemd-resolve -ErrorAction SilentlyContinue) {
-    Invoke-Step 'Flushing DNS cache...' { sudo systemd-resolve --flush-caches }
+    Invoke-Step 'Flushing DNS cache...' { systemd-resolve --flush-caches }
 }
 
 Write-Host "  Network reset complete.`n" -ForegroundColor Green

--- a/src/CLI/tools/linux/Invoke-NetworkReset.ps1
+++ b/src/CLI/tools/linux/Invoke-NetworkReset.ps1
@@ -28,7 +28,7 @@ function Invoke-Step {
 
 Write-Host "  Note: the network connection will drop briefly.`n" -ForegroundColor DarkGray
 
-$nmActive = (& systemctl is-active NetworkManager 2>$null).Trim() -eq 'active'
+$nmActive = (Get-PcCommandOutput 'systemctl' @('is-active', 'NetworkManager')) -eq 'active'
 
 if ($nmActive -or (Get-Command nmcli -ErrorAction SilentlyContinue)) {
     Invoke-Step 'Restarting NetworkManager...' { sudo systemctl restart NetworkManager }

--- a/src/CLI/tools/linux/Invoke-ScanAndRepair.ps1
+++ b/src/CLI/tools/linux/Invoke-ScanAndRepair.ps1
@@ -1,0 +1,73 @@
+﻿#Requires -Version 7.0
+# ============================================================================
+# pcHealth -- Scan + Repair (Linux)
+# Counterpart to SFC + DISM. SFC compares system files against the component
+# store; the package database is the same idea, so verify against that and
+# reinstall whatever no longer matches.
+# ============================================================================
+
+Write-Host "`n$('=' * 60)" -ForegroundColor Cyan
+Write-Host '  Scan + Repair  (package integrity)' -ForegroundColor Cyan
+Write-Host "$('=' * 60)`n" -ForegroundColor Cyan
+
+$pm = Get-PcPackageManager
+if (-not $pm) {
+    Write-Host "[!!] No supported package manager found (apt/dnf/pacman/zypper).`n" -ForegroundColor Red
+    return
+}
+
+$verifyCmd = $pm.Verify[0]
+if (-not (Get-Command $verifyCmd -ErrorAction SilentlyContinue)) {
+    Write-Host "[!!] $verifyCmd is not installed -- it does the checking, not $($pm.Cmd) itself." -ForegroundColor Red
+    Write-Host "     Install it with: $($pm.Cmd) $($pm.Install -join ' ') $verifyCmd`n" -ForegroundColor DarkGray
+    return
+}
+
+# -- Filesystem errors ---------------------------------------------------------
+# Read-only: fsck cannot safely touch a mounted root, so report what the kernel
+# has already seen and let the user schedule a repair from a live image.
+Write-Host '[>>] Step 1/2 -- Checking the kernel log for filesystem errors...' -ForegroundColor Yellow
+$fsErrors = @(& dmesg --level=err,warn 2>$null |
+    Where-Object { $_ -match 'EXT4-fs error|XFS.*Corruption|BTRFS error|I/O error|filesystem.*read-only' })
+
+if ($fsErrors) {
+    Write-Host "[!!] The kernel has logged filesystem errors:`n" -ForegroundColor Red
+    $fsErrors | Select-Object -Last 10 | ForEach-Object { Write-Host "  $_" -ForegroundColor DarkGray }
+    Write-Host "`n     Run fsck from a live image -- it cannot repair a mounted root.`n" -ForegroundColor Yellow
+} else {
+    Write-Host "[OK] No filesystem errors in the kernel log.`n" -ForegroundColor Green
+}
+
+# -- Package integrity ---------------------------------------------------------
+Write-Host "[>>] Step 2/2 -- Verifying installed packages with $verifyCmd..." -ForegroundColor Yellow
+Write-Host '     This reads every packaged file and takes several minutes.' -ForegroundColor DarkGray
+
+$confirm = (Read-Host "`n  Start the verification? (y/n)").Trim().ToLower()
+if ($confirm -ne 'y') {
+    Write-Host "`n  Skipped.`n" -ForegroundColor DarkGray
+    return
+}
+
+Write-Host ''
+$verifyArgs = @($pm.Verify[1..($pm.Verify.Count - 1)])
+# Merge stderr: debsums reports every changed file there, so discarding it would
+# turn a corrupted system into a clean bill of health. Empty stderr lines
+# stringify to the ErrorRecord type name, so drop those.
+$findings = @(& $verifyCmd @verifyArgs 2>&1 |
+    ForEach-Object { "$_".Trim() } |
+    Where-Object { $_ -and $_ -ne 'System.Management.Automation.RemoteException' })
+
+if (-not $findings) {
+    Write-Host "[OK] Every packaged file matches the package database.`n" -ForegroundColor Green
+    return
+}
+
+Write-Host "[!!] $($findings.Count) file(s) no longer match their package:`n" -ForegroundColor Red
+$findings | Select-Object -First 20 | ForEach-Object { Write-Host "  $_" -ForegroundColor DarkGray }
+if ($findings.Count -gt 20) {
+    Write-Host "  ... and $($findings.Count - 20) more" -ForegroundColor DarkGray
+}
+
+Write-Host ''
+Write-Host '  Config files you edited yourself show up here too -- that is expected.' -ForegroundColor DarkGray
+Write-Host "  Repair a package with: $($pm.Cmd) $($pm.Install -join ' ') --reinstall <package>`n" -ForegroundColor DarkGray

--- a/src/CLI/tools/linux/Invoke-ScanAndRepair.ps1
+++ b/src/CLI/tools/linux/Invoke-ScanAndRepair.ps1
@@ -16,6 +16,14 @@ if (-not $pm) {
     return
 }
 
+if (-not $pm.Verify) {
+    Write-Host "[!!] $($pm.Cmd) has no package-verification command." -ForegroundColor Red
+    Write-Host '     On an image-based system the running image is already verified;' -ForegroundColor Yellow
+    Write-Host '     check deployment state with: bootc status' -ForegroundColor DarkGray
+    Write-Host ''
+    return
+}
+
 $verifyCmd = $pm.Verify[0]
 if (-not (Get-Command $verifyCmd -ErrorAction SilentlyContinue)) {
     Write-Host "[!!] $verifyCmd is not installed -- it does the checking, not $($pm.Cmd) itself." -ForegroundColor Red

--- a/src/CLI/tools/linux/Invoke-ScanAndRepair.ps1
+++ b/src/CLI/tools/linux/Invoke-ScanAndRepair.ps1
@@ -16,14 +16,6 @@ if (-not $pm) {
     return
 }
 
-if (-not $pm.Verify) {
-    Write-Host "[!!] $($pm.Cmd) has no package-verification command." -ForegroundColor Red
-    Write-Host '     On an image-based system the running image is already verified;' -ForegroundColor Yellow
-    Write-Host '     check deployment state with: bootc status' -ForegroundColor DarkGray
-    Write-Host ''
-    return
-}
-
 $verifyCmd = $pm.Verify[0]
 if (-not (Get-Command $verifyCmd -ErrorAction SilentlyContinue)) {
     Write-Host "[!!] $verifyCmd is not installed -- it does the checking, not $($pm.Cmd) itself." -ForegroundColor Red

--- a/src/CLI/tools/linux/Invoke-SystemUpdate.ps1
+++ b/src/CLI/tools/linux/Invoke-SystemUpdate.ps1
@@ -1,0 +1,71 @@
+﻿#Requires -Version 7.0
+# ============================================================================
+# pcHealth -- Update all packages (Linux)
+# Distro-native counterpart to the winget update on Windows. Unlike Topgrade
+# this needs nothing installed beyond the package manager the distro ships.
+# ============================================================================
+
+Write-Host "`n$('=' * 60)" -ForegroundColor Cyan
+Write-Host '  Update all packages' -ForegroundColor Cyan
+Write-Host "$('=' * 60)`n" -ForegroundColor Cyan
+
+$pm = Get-PcPackageManager
+if (-not $pm) {
+    Write-Host "[!!] No supported package manager found (apt/dnf/pacman/zypper).`n" -ForegroundColor Red
+    return
+}
+
+Write-Host "  Package manager: $($pm.Cmd)`n" -ForegroundColor DarkGray
+
+if ($pm.Refresh) {
+    Write-Host '[>>] Refreshing package index...' -ForegroundColor Yellow
+    & $pm.Cmd @($pm.Refresh) 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "[!!] Refresh failed (exit code $LASTEXITCODE). Check your network connection.`n" -ForegroundColor Red
+        return
+    }
+}
+
+Write-Host "[>>] Checking for available updates...`n" -ForegroundColor Yellow
+# dnf check-update exits 100 when updates exist and 0 when there are none;
+# pacman -Qu exits 1 on an empty list. Judge by output, not exit code.
+# Discard stderr: every manager writes banners and progress there, and merged
+# ErrorRecords stringify to their type name rather than their text.
+$lines = @(& $pm.Cmd @($pm.List) 2>$null |
+    ForEach-Object { "$_".Trim() } |
+    Where-Object { $_ -and $_ -notmatch '^(Listing|Last metadata)' })
+
+if (-not $lines) {
+    Write-Host "[OK] Everything is already up to date.`n" -ForegroundColor Green
+    return
+}
+
+# A full-distro upgrade can list hundreds of packages; show enough to judge by.
+$preview = 15
+$lines | Select-Object -First $preview | ForEach-Object { Write-Host "  $_" -ForegroundColor DarkGray }
+if ($lines.Count -gt $preview) {
+    Write-Host "  ... and $($lines.Count - $preview) more" -ForegroundColor DarkGray
+}
+Write-Host "`n  $($lines.Count) update(s) available.`n" -ForegroundColor Cyan
+
+$confirm = (Read-Host '  Proceed with updating all packages? (y/n)').Trim().ToLower()
+if ($confirm -ne 'y') {
+    Write-Host "`n  Update cancelled.`n" -ForegroundColor DarkGray
+    return
+}
+
+Write-Host "`n[>>] Updating all packages...`n" -ForegroundColor Yellow
+& $pm.Cmd @($pm.Update)
+
+if ($LASTEXITCODE -eq 0) {
+    Write-Host "`n[OK] Update complete.`n" -ForegroundColor Green
+    # Kernel and glibc updates only take effect after a restart.
+    if (Get-Command needs-restarting -ErrorAction SilentlyContinue) {
+        & needs-restarting -r 2>&1 | Out-Null
+        if ($LASTEXITCODE -ne 0) { Write-Host "  [!] A reboot is required to finish this update.`n" -ForegroundColor Yellow }
+    } elseif (Test-Path '/var/run/reboot-required') {
+        Write-Host "  [!] A reboot is required to finish this update.`n" -ForegroundColor Yellow
+    }
+} else {
+    Write-Host "`n[!!] Update exited with code $LASTEXITCODE.`n" -ForegroundColor Red
+}

--- a/src/CLI/tools/linux/Invoke-SystemUpdate.ps1
+++ b/src/CLI/tools/linux/Invoke-SystemUpdate.ps1
@@ -16,6 +16,10 @@ if (-not $pm) {
 }
 
 Write-Host "  Package manager: $($pm.Cmd)`n" -ForegroundColor DarkGray
+if ($pm.Atomic) {
+    Write-Host '  Image-based system: this stages a new deployment rather than' -ForegroundColor DarkGray
+    Write-Host "  patching the running one. It takes effect after a reboot.`n" -ForegroundColor DarkGray
+}
 
 if ($pm.Refresh) {
     Write-Host '[>>] Refreshing package index...' -ForegroundColor Yellow
@@ -60,7 +64,9 @@ Write-Host "`n[>>] Updating all packages...`n" -ForegroundColor Yellow
 if ($LASTEXITCODE -eq 0) {
     Write-Host "`n[OK] Update complete.`n" -ForegroundColor Green
     # Kernel and glibc updates only take effect after a restart.
-    if (Get-Command needs-restarting -ErrorAction SilentlyContinue) {
+    if ($pm.Atomic) {
+        Write-Host "  [!] Reboot to boot into the new deployment.`n" -ForegroundColor Yellow
+    } elseif (Get-Command needs-restarting -ErrorAction SilentlyContinue) {
         & needs-restarting -r 2>&1 | Out-Null
         if ($LASTEXITCODE -ne 0) { Write-Host "  [!] A reboot is required to finish this update.`n" -ForegroundColor Yellow }
     } elseif (Test-Path '/var/run/reboot-required') {

--- a/src/CLI/tools/linux/Invoke-SystemUpdate.ps1
+++ b/src/CLI/tools/linux/Invoke-SystemUpdate.ps1
@@ -16,10 +16,6 @@ if (-not $pm) {
 }
 
 Write-Host "  Package manager: $($pm.Cmd)`n" -ForegroundColor DarkGray
-if ($pm.Atomic) {
-    Write-Host '  Image-based system: this stages a new deployment rather than' -ForegroundColor DarkGray
-    Write-Host "  patching the running one. It takes effect after a reboot.`n" -ForegroundColor DarkGray
-}
 
 if ($pm.Refresh) {
     Write-Host '[>>] Refreshing package index...' -ForegroundColor Yellow
@@ -64,9 +60,7 @@ Write-Host "`n[>>] Updating all packages...`n" -ForegroundColor Yellow
 if ($LASTEXITCODE -eq 0) {
     Write-Host "`n[OK] Update complete.`n" -ForegroundColor Green
     # Kernel and glibc updates only take effect after a restart.
-    if ($pm.Atomic) {
-        Write-Host "  [!] Reboot to boot into the new deployment.`n" -ForegroundColor Yellow
-    } elseif (Get-Command needs-restarting -ErrorAction SilentlyContinue) {
+    if (Get-Command needs-restarting -ErrorAction SilentlyContinue) {
         & needs-restarting -r 2>&1 | Out-Null
         if ($LASTEXITCODE -ne 0) { Write-Host "  [!] A reboot is required to finish this update.`n" -ForegroundColor Yellow }
     } elseif (Test-Path '/var/run/reboot-required') {

--- a/src/CLI/tools/linux/Invoke-Topgrade.ps1
+++ b/src/CLI/tools/linux/Invoke-Topgrade.ps1
@@ -14,10 +14,14 @@ if (-not (Get-Command topgrade -ErrorAction SilentlyContinue)) {
     Write-Host ''
     Write-Host '  Install it with your package manager:' -ForegroundColor DarkGray
     Write-Host '    Arch / CachyOS / Manjaro:  sudo pacman -S topgrade' -ForegroundColor DarkGray
-    Write-Host '    Debian / Ubuntu:           cargo install topgrade'  -ForegroundColor DarkGray
-    Write-Host '    Fedora:                    cargo install topgrade'  -ForegroundColor DarkGray
-    Write-Host '    All (cargo):               cargo install topgrade'  -ForegroundColor DarkGray
+    Write-Host '    Debian / Ubuntu / Fedora:  cargo install topgrade'  -ForegroundColor DarkGray
     Write-Host ''
+    return
+}
+
+$user = Get-PcDesktopUser
+if (-not $user) {
+    Write-Host "[!!] Could not determine the desktop user.`n" -ForegroundColor Red
     return
 }
 
@@ -26,32 +30,33 @@ Write-Host '    packages, flatpak, VS Code extensions, uv tools,' -ForegroundCol
 Write-Host '    gcloud, helm, firmware, and more.' -ForegroundColor DarkGray
 Write-Host ''
 
-$user   = $env:SUDO_USER ?? $env:USER
-$userId = (& id -u $user 2>$null).Trim()
-
 # Reconstruct the session environment so GNOME Shell extensions and
-# session-aware tools (gcloud, gdbus) work when topgrade is spawned from
-# a sudo context that doesn't inherit the user's graphical session.
-$dbusAddr      = $env:DBUS_SESSION_BUS_ADDRESS ?? "unix:path=/run/user/$userId/bus"
-$waylandDisplay = $env:WAYLAND_DISPLAY ?? 'wayland-0'
-$xDisplay      = $env:DISPLAY ?? ':0'
-
-$envSetup = "export DBUS_SESSION_BUS_ADDRESS='$dbusAddr'; export WAYLAND_DISPLAY='$waylandDisplay'; export DISPLAY='$xDisplay';"
-$cmd      = "$envSetup topgrade; echo; read -p 'Press Enter to close...'"
-
-$terminals = @(
-    @{ cmd = 'gnome-terminal'; args = @('--wait', '--', 'sudo', '-u', $user, 'bash', '-c', $cmd) }
-    @{ cmd = 'konsole';        args = @('--hold', '-e', 'sudo', '-u', $user, 'bash', '-c', $cmd) }
-    @{ cmd = 'alacritty';      args = @('-e', 'sudo', '-u', $user, 'bash', '-c', $cmd) }
-    @{ cmd = 'kitty';          args = @('sudo', '-u', $user, 'bash', '-c', $cmd) }
-    @{ cmd = 'xfce4-terminal'; args = @('--hold', '-e', 'sudo', '-u', $user, 'bash', '-c', $cmd) }
-    @{ cmd = 'xterm';          args = @('-hold', '-e', 'sudo', '-u', $user, 'bash', '-c', $cmd) }
+# session-aware tools (gcloud, gdbus) work when topgrade is spawned from a sudo
+# context that doesn't inherit the user's graphical session.
+# Each value is a separate argv token for `env` rather than text spliced into a
+# shell command, so a hostile DISPLAY cannot become an extra command.
+$sessionEnv = @(
+    "DBUS_SESSION_BUS_ADDRESS=$($user.Dbus)"
+    "WAYLAND_DISPLAY=$($env:WAYLAND_DISPLAY ?? 'wayland-0')"
+    "DISPLAY=$($env:DISPLAY ?? ':0')"
 )
+# Fixed literal -- the shell is only here to hold the window open afterwards.
+$runCmd = @('sudo', '-u', $user.Name, 'env') + $sessionEnv +
+          @('bash', '-c', 'topgrade; echo; read -r -p "Press Enter to close..."')
 
-foreach ($term in $terminals) {
-    if (Get-Command $term.cmd -ErrorAction SilentlyContinue) {
-        Write-Host "[>>] Opening topgrade in $($term.cmd)..." -ForegroundColor Yellow
-        & $term.cmd @($term.args)
+$terminals = [ordered]@{
+    'gnome-terminal' = @('--wait', '--')
+    'konsole'        = @('--hold', '-e')
+    'alacritty'      = @('-e')
+    'kitty'          = @()
+    'xfce4-terminal' = @('--hold', '-e')
+    'xterm'          = @('-hold', '-e')
+}
+
+foreach ($term in $terminals.Keys) {
+    if (Get-Command $term -ErrorAction SilentlyContinue) {
+        Write-Host "[>>] Opening topgrade in $term..." -ForegroundColor Yellow
+        & $term @($terminals[$term] + $runCmd)
         return
     }
 }

--- a/src/GUI/pcHealth/Pages/HealthPage.xaml.cs
+++ b/src/GUI/pcHealth/Pages/HealthPage.xaml.cs
@@ -446,7 +446,12 @@ public sealed partial class HealthPage : Page
                                         : "Idle  (plugged in, not charging)";
             }
         }
-        catch { }
+        catch (Exception ex)
+        {
+            // Ticks every 3s, so log at Debug: a removed or sleeping battery
+            // would otherwise fill the log with the same entry.
+            NLog.LogManager.GetCurrentClassLogger().Debug(ex, "Live battery reading failed");
+        }
     }
 
     private CheckStatus PopulateSecurityCard(StackPanel panel, SecurityInfo data, Expander expander)

--- a/src/GUI/pcHealth/Services/IProcessRunner.cs
+++ b/src/GUI/pcHealth/Services/IProcessRunner.cs
@@ -2,7 +2,8 @@ namespace pcHealth.Services;
 
 public interface IProcessRunner
 {
-    Task RunAsync(
+    /// <summary>Runs a process and returns its exit code.</summary>
+    Task<int> RunAsync(
         string fileName,
         string arguments,
         Action<string> onLine,

--- a/src/GUI/pcHealth/Services/ProcessRunner.cs
+++ b/src/GUI/pcHealth/Services/ProcessRunner.cs
@@ -1,10 +1,11 @@
 using System.Diagnostics;
+using System.Text.RegularExpressions;
 
 namespace pcHealth.Services;
 
-internal sealed class ProcessRunner : IProcessRunner
+internal sealed partial class ProcessRunner : IProcessRunner
 {
-    public async Task RunAsync(
+    public async Task<int> RunAsync(
         string fileName,
         string arguments,
         Action<string> onLine,
@@ -22,8 +23,8 @@ internal sealed class ProcessRunner : IProcessRunner
         };
 
         using var proc = new Process { StartInfo = psi };
-        proc.OutputDataReceived += (_, e) => { if (e.Data is not null) onLine(e.Data); };
-        proc.ErrorDataReceived += (_, e) => { if (e.Data is not null) onLine(e.Data); };
+        proc.OutputDataReceived += (_, e) => { if (e.Data is not null) onLine(StripAnsi(e.Data)); };
+        proc.ErrorDataReceived += (_, e) => { if (e.Data is not null) onLine(StripAnsi(e.Data)); };
 
         proc.Start();
         proc.BeginOutputReadLine();
@@ -51,5 +52,14 @@ internal sealed class ProcessRunner : IProcessRunner
         {
             timeoutCts?.Dispose();
         }
+
+        return proc.ExitCode;
     }
+
+    // pwsh and third-party scripts colour their output; a TextBlock renders the
+    // escapes literally. Stripped here so every page benefits.
+    [GeneratedRegex(@"\x1B(?:\[[0-9;?]*[ -/]*[@-~]|\][^\x07\x1B]*(?:\x07|\x1B\\))")]
+    private static partial Regex AnsiPattern();
+
+    private static string StripAnsi(string line) => AnsiPattern().Replace(line, string.Empty);
 }

--- a/src/GUI/pcHealth/ViewModels/BootRepairViewModel.cs
+++ b/src/GUI/pcHealth/ViewModels/BootRepairViewModel.cs
@@ -30,16 +30,27 @@ public partial class BootRepairViewModel : ObservableObject
         {
             var bootrec = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "bootrec.exe");
 
-            Append("[>>] bootrec /fixmbr");
-            await _runner.RunAsync(bootrec, "/fixmbr", Append, ct);
-            Append("\n[>>] bootrec /fixboot");
-            await _runner.RunAsync(bootrec, "/fixboot", Append, ct);
-            Append("\n[>>] bootrec /scanos");
-            await _runner.RunAsync(bootrec, "/scanos", Append, ct);
-            Append("\n[>>] bootrec /rebuildbcd");
-            await _runner.RunAsync(bootrec, "/rebuildbcd", Append, ct);
-            Append("\n[OK] Boot repair complete. Reboot the system to verify.");
-            Status = "Done. Reboot required.";
+            var failed = new List<string>();
+            foreach (var step in new[] { "/fixmbr", "/fixboot", "/scanos", "/rebuildbcd" })
+            {
+                Append($"\n[>>] bootrec {step}");
+                if (await _runner.RunAsync(bootrec, step, Append, ct) != 0)
+                    failed.Add(step);
+            }
+
+            if (failed.Count == 0)
+            {
+                Append("\n[OK] Boot repair complete. Reboot the system to verify.");
+                Status = "Done. Reboot required.";
+            }
+            else
+            {
+                // /fixboot returns "Access is denied" on every EFI system, so a
+                // failure here is expected on modern hardware rather than alarming.
+                Append($"\n[!!] These steps failed: {string.Join(", ", failed)}.");
+                Append("     On a UEFI/GPT system that is normal for /fixmbr and /fixboot.");
+                Status = "Completed with errors.";
+            }
         }
         catch (OperationCanceledException)
         {

--- a/src/GUI/pcHealth/ViewModels/NetworkResetViewModel.cs
+++ b/src/GUI/pcHealth/ViewModels/NetworkResetViewModel.cs
@@ -47,14 +47,24 @@ public partial class NetworkResetViewModel : ObservableObject
                 Append("[>>] Resetting Winsock catalog…");
             });
 
-            await _runner.RunAsync("netsh.exe", "winsock reset catalog", Append);
-            Append("[OK] Winsock reset.");
+            int winsock = await _runner.RunAsync("netsh.exe", "winsock reset catalog", Append);
+            Append(winsock == 0 ? "[OK] Winsock reset." : $"[!!] Winsock reset failed (exit {winsock}).");
+
             Append("[>>] Resetting IPv4 stack…");
-            await _runner.RunAsync("netsh.exe", "int ipv4 reset", Append);
+            int v4 = await _runner.RunAsync("netsh.exe", "int ipv4 reset", Append);
             Append("[>>] Resetting IPv6 stack…");
-            await _runner.RunAsync("netsh.exe", "int ipv6 reset", Append);
-            Append("\n[OK] Network stack reset complete. Reboot to apply all changes.");
-            Status = "Done. Reboot recommended.";
+            int v6 = await _runner.RunAsync("netsh.exe", "int ipv6 reset", Append);
+
+            if (winsock == 0 && v4 == 0 && v6 == 0)
+            {
+                Append("\n[OK] Network stack reset complete. Reboot to apply all changes.");
+                Status = "Done. Reboot recommended.";
+            }
+            else
+            {
+                Append($"\n[!!] Some steps failed (winsock {winsock}, IPv4 {v4}, IPv6 {v6}). Run as Administrator.");
+                Status = "Completed with errors.";
+            }
         }
         catch (Exception ex)
         {

--- a/src/GUI/pcHealth/ViewModels/TracerouteViewModel.cs
+++ b/src/GUI/pcHealth/ViewModels/TracerouteViewModel.cs
@@ -40,7 +40,12 @@ public partial class TracerouteViewModel : ObservableObject
                 targetAddress = addresses.FirstOrDefault(a => a.AddressFamily == AddressFamily.InterNetwork)
                     ?? addresses.FirstOrDefault();
             }
-            catch { }
+            catch (Exception ex) when (ex is SocketException or ArgumentException)
+            {
+                // Not fatal: the trace still runs, it just cannot mark the final hop.
+                // ArgumentException covers a malformed target the user typed.
+                Log.Debug(ex, "Could not resolve {Target}", Target);
+            }
 
             await Task.Run(async () =>
             {

--- a/src/GUI/pcHealth/ViewModels/WingetRepairViewModel.cs
+++ b/src/GUI/pcHealth/ViewModels/WingetRepairViewModel.cs
@@ -29,17 +29,39 @@ public partial class WingetRepairViewModel : ObservableObject
         try
         {
             Append("[>>] Installing winget-install script from PSGallery…");
-            await _runner.RunAsync("pwsh.exe",
+            int installExit = await _runner.RunAsync("pwsh.exe",
                 "-NoProfile -ExecutionPolicy Bypass -Command \"Install-Script -Name winget-install -Force -Scope CurrentUser\"",
                 Append, ct);
 
+            if (installExit != 0)
+            {
+                Append($"\n[!!] Could not install the script from PSGallery (exit {installExit}).");
+                Status = "Failed.";
+                return;
+            }
+
+            // Install-Script drops winget-install.ps1 into the CurrentUser scripts
+            // folder, which is not on PATH for this process -- calling it by bare
+            // name fails with "not recognized". Resolve the real path first, the
+            // same way the CLI tool does.
             Append("\n[>>] Running winget-install…");
-            await _runner.RunAsync("pwsh.exe",
-                "-NoProfile -ExecutionPolicy Bypass -Command \"winget-install -Force\"",
+            const string runScript =
+                "$p = (Get-InstalledScript winget-install -ErrorAction SilentlyContinue).InstalledLocation; " +
+                "if ($p) { & (Join-Path $p 'winget-install.ps1') -Force } else { winget-install -Force }";
+            int runExit = await _runner.RunAsync("pwsh.exe",
+                $"-NoProfile -ExecutionPolicy Bypass -Command \"{runScript}\"",
                 Append, ct);
 
-            Append("\n[OK] Winget repair complete.");
-            Status = "Done.";
+            if (runExit == 0)
+            {
+                Append("\n[OK] Winget repair complete.");
+                Status = "Done.";
+            }
+            else
+            {
+                Append($"\n[!!] winget-install exited with code {runExit}.");
+                Status = "Failed.";
+            }
         }
         catch (OperationCanceledException)
         {

--- a/src/GUI/pcHealth/pcHealth.csproj
+++ b/src/GUI/pcHealth/pcHealth.csproj
@@ -8,7 +8,8 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net10.0-windows10.0.26100.0</TargetFramework>
-    <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
+    <!-- Matches the supported floor: Windows 11 25H2 (build 26200). -->
+    <TargetPlatformMinVersion>10.0.26100.0</TargetPlatformMinVersion>
     <RootNamespace>pcHealth</RootNamespace>
     <AssemblyName>pcHealth</AssemblyName>
     <ApplicationIcon>Assets\pcHealth.ico</ApplicationIcon>


### PR DESCRIPTION
## Summary

An audit and modernisation pass over the CLI and GUI, the Linux work that closes tool-level parity with Windows, and a move to a modern-only supported range. Every finding below was reproduced by running the code in a PowerShell 7.5.4 sandbox, not by reading it.

Seven Linux tools added, eight bugs fixed, one shell-injection surface removed, and all MBR/CSM boot code retired.

## Type of change

**Conventional Commit Types** - choose one:

- [x] `feat` - [#0075ca](https://img.shields.io/badge/-0075ca) new functionality visible to the user
- [ ] `fix` - [#d73a4a](https://img.shields.io/badge/-d73a4a) bug fix
- [ ] `refactor` - [#fbca04](https://img.shields.io/badge/-fbca04) code restructure without behavior change
- [ ] `perf` - [#d4c5f9](https://img.shields.io/badge/-d4c5f9) performance improvement
- [ ] `docs` - [#0075ca](https://img.shields.io/badge/-0075ca) documentation only
- [ ] `chore` - [#e4e669](https://img.shields.io/badge/-e4e669) maintenance, cleanup, configuration
- [ ] `style` - [#bfd4f2](https://img.shields.io/badge/-bfd4f2) formatting only, no logic change
- [ ] `test` - [#c2e0c6](https://img.shields.io/badge/-c2e0c6) test additions or changes
- [ ] `ci` - [#006b75](https://img.shields.io/badge/-006b75) CI/CD workflow changes
- [ ] `deps` - [#0366d6](https://img.shields.io/badge/-0366d6) dependency or action version update
- [ ] `build` - [#fdb913](https://img.shields.io/badge/-fdb913) build system or tooling change
- [ ] `revert` - [#f9d0c4](https://img.shields.io/badge/-f9d0c4) reverts a previous commit

Breaking change?
- [x] Yes - I used `feat!:` or `BREAKING CHANGE` in my commit

## Boot repair, rebuilt for UEFI

On Windows the MBR-era steps were already dead code: `bootrec /fixmbr` wrote boot code nothing on a GPT disk reads, and `/fixboot` returns "Access is denied" on EFI — which is why the `bcdboot` fallback underneath it was doing the real repair all along. It now refuses on non-UEFI firmware, runs `bcdboot` against the ESP with `/f UEFI` rather than `/f ALL`, and releases the ESP afterwards.

The new Linux counterpart supports **systemd-boot, GRUB and Limine**. Design constraints, given that a mistake here costs a bootable machine:


## Checklist

- [x] PR title follows conventional commits (e.g. `fix: resolve startup crash`)
- [x] CI is green
- [x] No passwords, API keys or sensitive data in the code